### PR TITLE
fix(cp): harden network reset userscript with safe deletes and org fallback

### DIFF
--- a/user.js/peeringdb-cp-reset-all-network-information.meta.js
+++ b/user.js/peeringdb-cp-reset-all-network-information.meta.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         PeeringDB CP - Reset all network information
 // @namespace    https://www.peeringdb.net/
-// @version      0.1.0.20260217
+// @version      0.1.1.20260217
 // @description  Reset all information for the network due to reassigned ASN by the RIPE NCC
 // @author       <chriztoffer@peeringdb.com>
 // @match        https://www.peeringdb.com/cp/peeringdb_server/network/*/change/*


### PR DESCRIPTION
## Description
Hardens the CP "Reset all network information" userscript using safer, modular reset logic and resilient organization-name fallback handling.

## Changes
- Refactor reset steps to isolate selector failures via guarded execution.
- Split inline delete handling into dedicated handlers for contacts, facilities, and netixlan rows.
- Trigger delete by clicking each inline delete handler for targeted row sets.
- Add org API error handling, including a 404 fallback to the original `#id_name` value.
- Add variable annotations for maintainability.
- Bump userscript/meta patch version to `0.1.1`.

## Checklist
- [x] Title follows type(scope): description
- [x] Labels applied
- [x] Assignee set to me
- [x] No restricted ticket reference