### PR TITLE
fix(cp): ensure first-run name persistence and bump reset script patch version

### DIFF
--- a/user.js/peeringdb-cp-reset-all-network-information.meta.js
+++ b/user.js/peeringdb-cp-reset-all-network-information.meta.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         PeeringDB CP - Reset all network information
 // @namespace    https://www.peeringdb.net/
-// @version      0.1.1.20260217
+// @version      0.1.2.20260217
 // @description  Reset all information for the network due to reassigned ASN by the RIPE NCC
 // @author       <chriztoffer@peeringdb.com>
 // @match        https://www.peeringdb.com/cp/peeringdb_server/network/*/change/*


### PR DESCRIPTION
## Description
Fixes first-run reset behavior where the network name could remain blank and block save, and includes a bugfix version bump for the reset userscript.

## Changes
- Ensure resolved network name is written to the live input value before submit.
- Add a final guard to restore original name if required input is still empty.
- Keep fallback handling for org API errors, including 404 scenarios.
- Bump `peeringdb-cp-reset-all-network-information` patch version from `0.1.1` to `0.1.2` in `.user.js` and `.meta.js`.

## Checklist
- [x] Title follows type(scope): description
- [x] Labels applied
- [x] Assignee set to me
- [x] No restricted ticket reference