### PR TITLE
CP userscript: stabilize network toolbar ordering and reset UX

### DIFF
--- a/user.js/peeringdb-cp-consolidated-tools.meta.js
+++ b/user.js/peeringdb-cp-consolidated-tools.meta.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         PeeringDB CP - Consolidated Tools
 // @namespace    https://www.peeringdb.com/cp/
-// @version      1.0.15.20260223
+// @version      1.0.35.20260223
 // @description  Consolidated CP userscript with strict route-isolated modules for facility/network/user/entity workflows
 // @author       <chriztoffer@peeringdb.com>
 // @match        https://www.peeringdb.com/cp/peeringdb_server/*/*/change/*

--- a/user.js/peeringdb-cp-consolidated-tools.meta.js
+++ b/user.js/peeringdb-cp-consolidated-tools.meta.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         PeeringDB CP - Consolidated Tools
 // @namespace    https://www.peeringdb.com/cp/
-// @version      1.0.9.20260223
+// @version      1.0.15.20260223
 // @description  Consolidated CP userscript with strict route-isolated modules for facility/network/user/entity workflows
 // @author       <chriztoffer@peeringdb.com>
 // @match        https://www.peeringdb.com/cp/peeringdb_server/*/*/change/*


### PR DESCRIPTION
## Summary
This PR includes all commits on `feat/cp-unified-userscript-modular-runtime-isolation` since it diverged from `master`.

### Included commits
- `398845c` chore(user.js): standardize toolbar labels to Org naming
- `323e223` fix(userscript): stabilize CP network toolbar order and reset UX

## What changed
- Standardized toolbar naming toward "Org" terminology.
- Stabilized deterministic primary toolbar order on CP network change pages.
- Fixed native `History` item ordering by matching non-custom toolbar list items via href/text.
- Enforced deterministic secondary action row order:
  - Copy network URL
  - Copy Org URL
- Preserved Grappelli visual style while preventing row overlap/offset issues.
- Increased spacing between secondary action row and Verification queue section.
- Added one reset confirmation prompt with contextual target information (`ID / AS / Name`).
- Performed helper tidy-up for ordering logic with no behavior change intent.
- Version updated to `1.0.35` in both userscript and meta files.

## Files changed
- `user.js/peeringdb-cp-consolidated-tools.user.js`
- `user.js/peeringdb-cp-consolidated-tools.meta.js`

## Validation
- Visual verification confirmed expected toolbar order and spacing.
- Quick diagnostics reported no script errors in modified files.

## Labels rationale
- `bug`: ordering/placement issue fixed (History position + overlap behavior)
- `enhancement`: UX polish and safer reset confirmation context
- `userscript`: changes are focused on Tampermonkey userscript files
- `llm-assisted`: prepared with AI assistance