### PR TITLE
feat(fp-toolbar): stabilize two-row FP toolbar actions and overflow

### DIFF
--- a/user.js/peeringdb-fp-consolidated-tools.meta.js
+++ b/user.js/peeringdb-fp-consolidated-tools.meta.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         PeeringDB FP - Consolidated Tools
 // @namespace    https://www.peeringdb.com/
-// @version      1.0.2.20260223
+// @version      1.0.15.20260224
 // @description  Consolidated FP userscript for PeeringDB frontend (Net/Org/Fac/IX/Carrier)
 // @author       <chriztoffer@peeringdb.com>
 // @match        https://www.peeringdb.com/*

--- a/user.js/peeringdb-fp-consolidated-tools.user.js
+++ b/user.js/peeringdb-fp-consolidated-tools.user.js
@@ -388,6 +388,8 @@
     const parent = getTopRightToolbarContainer();
     if (!parent) return;
 
+    applyTopRightToolbarFlexLayout(parent);
+
     // FP top-right ordering policy:
     // 1) keep native Edit first (when present)
     // 2) order custom actions deterministically for consistency with CP conventions
@@ -399,6 +401,8 @@
       'a[data-pdb-fp-action="bgp-tools"]',
       'a[data-pdb-fp-action="bgp-he-net"]',
     ]);
+
+    routeTopRightButtonsToTwoRows(parent);
 
     applyTopRightCustomSpacing(parent);
   }

--- a/user.js/peeringdb-fp-consolidated-tools.user.js
+++ b/user.js/peeringdb-fp-consolidated-tools.user.js
@@ -542,6 +542,19 @@
                 target: "_blank",
               });
             });
+
+            createTopRightOverflowMenu({
+              actionId: "network-tools-overflow",
+              label: "More Tools",
+              items: [
+                { label: "RIPEstat", url: `https://stat.ripe.net/AS${asn}` },
+                { label: "BGPView", url: `https://bgpview.io/asn/${asn}` },
+                { label: "CIDR Report", url: `https://www.cidr-report.org/cgi-bin/as-report?as=${asn}` },
+                { label: "IPinfo", url: `https://ipinfo.io/AS${asn}` },
+                { label: "CF Radar", url: `https://radar.cloudflare.com/as${asn}` },
+                { label: "RouteViews", url: "https://routeviews.org/" },
+              ],
+            });
           }
 
           // Remove edit button if no website (legacy feature port)

--- a/user.js/peeringdb-fp-consolidated-tools.user.js
+++ b/user.js/peeringdb-fp-consolidated-tools.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         PeeringDB FP - Consolidated Tools
 // @namespace    https://www.peeringdb.com/
-// @version      1.0.3.20260223
+// @version      1.0.15.20260224
 // @description  Consolidated FP userscript for PeeringDB frontend (Net/Org/Fac/IX/Carrier)
 // @author       <chriztoffer@peeringdb.com>
 // @match        https://www.peeringdb.com/*

--- a/user.js/peeringdb-fp-consolidated-tools.user.js
+++ b/user.js/peeringdb-fp-consolidated-tools.user.js
@@ -400,11 +400,13 @@
       'a[data-pdb-fp-action="copy-url"]',
       'a[data-pdb-fp-action="bgp-tools"]',
       'a[data-pdb-fp-action="bgp-he-net"]',
+      '[data-pdb-fp-action="network-tools-overflow"]',
     ]);
 
     routeTopRightButtonsToTwoRows(parent);
 
     applyTopRightCustomSpacing(parent);
+    applyTopRightWrappedRowOffset(parent);
   }
 
   function addButton(label, onClick, parentSelector = "div.right.button-bar > div:first-child", actionId = "") {
@@ -531,7 +533,7 @@
           if (asn) {
             [
               { id: "bgp-tools", label: "BGP.TOOLS", url: `https://bgp.tools/as${asn}` },
-              { id: "bgp-he-net", label: "BGP.HE.NET", url: `https://bgp.he.net/as${asn}` },
+              { id: "bgp-he-net", label: "BGP.HE", url: `https://bgp.he.net/as${asn}` },
             ].forEach((tool) => {
               createTopRightAction({
                 actionId: tool.id,


### PR DESCRIPTION
## Summary
This PR ports and finalizes frontend toolbar improvements in the consolidated FP userscript, then replays the branch history with corrected commit-message formatting.

## What changed
- Added top-right toolbar layout primitives for deterministic rendering.
- Wired enforce-flow routing into an explicit two-row toolbar structure.
- Finalized action ordering behavior and button-label polish (`BGP.HE`).
- Added network `More Tools` overflow action with curated external links.
- Synced consolidated userscript/meta versions to `1.0.15`.

## Commit-history cleanup
- Replayed commits on a `-reword` branch with proper multiline commit bodies.
- Avoided literal escaped newline tokens in commit messages.

## Verification
- Visual checks performed on frontend snapshots for:
  - two-row toolbar behavior,
  - consistent spacing,
  - content-based button widths,
  - right-most placement of `More Tools` on row 2.
- Local branch is pushed and ready for review.
