### PR TITLE
fix(cp): refine rendered field copy exclusions

### DIFF
--- a/user.js/README.md
+++ b/user.js/README.md
@@ -36,6 +36,179 @@ All legacy Frontend (`peeringdb-fp-*`) scripts have been consolidated into one m
 - `peeringdb-fp-consolidated-tools.user.js`
 - `peeringdb-fp-consolidated-tools.meta.js`
 
+## Module feature flags (CP + FP)
+
+Both consolidated scripts support disabling specific modules with `localStorage`.
+
+- CP key: `pdbCpConsolidated.disabledModules`
+- FP key: `pdbFpConsolidated.disabledModules`
+
+### User-Agent Configuration (CP + FP)
+
+Both scripts support trust-based User-Agent generation inspired by the [python_modules/useragent.py](../python_modules/useragent.py) module:
+
+**Trust-Based Logic:**
+- **Trusted domains** (peeringdb.com, *.peeringdb.com, api.peeringdb.com, 127.0.0.1, localhost): Full-detail UA including browser platform, session UUID, e.g. `PeeringDB-Admincom-CP-Consolidated (Windows NT 10.0 uuid/123abc...)`
+- **Untrusted domains** (other origins in extension requests): Privacy-preserving UA with 16-char Client Fingerprint (deterministic hash of browser attributes) + session UUID, e.g. `PeeringDB-Admincom-CP-Consolidated (fingerprint/a3f2c8e1d4b6f9a2 uuid/123abc...)`
+
+**Storage Keys:**
+- CP User-Agent key: `pdbCpConsolidated.userAgent` (localStorage)
+- FP User-Agent key: `pdbFpConsolidated.userAgent` (localStorage)
+- CP Session UUID key: `pdbCpConsolidated.sessionUuid` (sessionStorage)
+- FP Session UUID key: `pdbFpConsolidated.sessionUuid` (sessionStorage)
+
+**Default behavior (no localStorage override):**
+- Scripts auto-compute trust-based UA on each request based on target domain
+- Session UUID is generated once per session and persisted in `sessionStorage`
+- Client Fingerprint is computed deterministically from browser attributes (userAgent, platform, language, hardwareConcurrency, deviceMemory)
+
+**Optional localStorage override:**
+- CP custom User-Agent: `pdbCpConsolidated.userAgent`
+- FP custom User-Agent: `pdbFpConsolidated.userAgent`
+- When set, overrides auto-computed trust-based UA
+
+Values can be either:
+
+- JSON array: `"[\"module-a\",\"module-b\"]"`
+- Comma-separated string: `"module-a,module-b"`
+
+### Console examples
+
+Disable one CP module:
+
+```js
+localStorage.setItem("pdbCpConsolidated.disabledModules", '["reset-network-information"]');
+```
+
+Disable multiple FP modules:
+
+```js
+localStorage.setItem("pdbFpConsolidated.disabledModules", "copy-user-roles,admin-console-link");
+```
+
+Re-enable all modules:
+
+```js
+localStorage.removeItem("pdbCpConsolidated.disabledModules");
+localStorage.removeItem("pdbFpConsolidated.disabledModules");
+```
+
+Inspect auto-computed CP User-Agent (trust-based, no override):
+
+```js
+console.log("Session UUID:", window.sessionStorage?.getItem("pdbCpConsolidated.sessionUuid"));
+console.log("CPU configured?:", !!localStorage.getItem("pdbCpConsolidated.userAgent"));
+```
+
+Set custom CP request User-Agent (overrides auto-computed):
+
+```js
+localStorage.setItem("pdbCpConsolidated.userAgent", "PeeringDB-Admincom/CP-RDAP (+tampermonkey)");
+```
+
+Set custom FP request User-Agent:
+
+```js
+localStorage.setItem("pdbFpConsolidated.userAgent", "PeeringDB-Admincom/FP (+custom)");
+```
+
+Reset CP/FP User-Agent to auto-computed (trust-based logic):
+
+```js
+localStorage.removeItem("pdbCpConsolidated.userAgent");
+localStorage.removeItem("pdbFpConsolidated.userAgent");
+```
+
+After updating flags, reload the page so modules are re-evaluated.
+
+Note: User-Agent (whether auto-computed or overridden) applies to script-originated extension requests only (for example RDAP lookups in CP). It does not change normal browser navigation/request User-Agent. FP currently has no extension request paths; UA scaffolding is pre-wired for future use.
+
+## Module ID catalog
+
+Use these module IDs with the CP/FP `disabledModules` keys.
+
+### CP module IDs (`peeringdb-cp-consolidated-tools.user.js`)
+
+- `copy-frontend-urls`
+- `facility-google-maps`
+- `entity-website-new-tab`
+- `highlight-dummy-org-child`
+- `frontend-links`
+- `search-user-email-by-username`
+- `set-network-name-equal-org-name`
+- `reset-network-information`
+- `set-window-title`
+
+#### CP one-line disable examples
+
+```js
+localStorage.setItem("pdbCpConsolidated.disabledModules", '["copy-frontend-urls"]');
+localStorage.setItem("pdbCpConsolidated.disabledModules", '["facility-google-maps"]');
+localStorage.setItem("pdbCpConsolidated.disabledModules", '["entity-website-new-tab"]');
+localStorage.setItem("pdbCpConsolidated.disabledModules", '["highlight-dummy-org-child"]');
+localStorage.setItem("pdbCpConsolidated.disabledModules", '["frontend-links"]');
+localStorage.setItem("pdbCpConsolidated.disabledModules", '["search-user-email-by-username"]');
+localStorage.setItem("pdbCpConsolidated.disabledModules", '["set-network-name-equal-org-name"]');
+localStorage.setItem("pdbCpConsolidated.disabledModules", '["reset-network-information"]');
+localStorage.setItem("pdbCpConsolidated.disabledModules", '["set-window-title"]');
+```
+
+### FP module IDs (`peeringdb-fp-consolidated-tools.user.js`)
+
+- `fix-double-slashes`
+- `set-window-title`
+- `admin-console-link`
+- `copy-record-data`
+- `copy-user-roles`
+
+#### FP one-line disable examples
+
+```js
+localStorage.setItem("pdbFpConsolidated.disabledModules", '["fix-double-slashes"]');
+localStorage.setItem("pdbFpConsolidated.disabledModules", '["set-window-title"]');
+localStorage.setItem("pdbFpConsolidated.disabledModules", '["admin-console-link"]');
+localStorage.setItem("pdbFpConsolidated.disabledModules", '["copy-record-data"]');
+localStorage.setItem("pdbFpConsolidated.disabledModules", '["copy-user-roles"]');
+```
+
+### Whitelist troubleshooting examples (enable only selected modules)
+
+These one-liners disable every other known module, leaving only the listed module(s) enabled.
+
+Enable only `reset-network-information` in CP:
+
+```js
+localStorage.setItem("pdbCpConsolidated.disabledModules", JSON.stringify(["copy-frontend-urls","facility-google-maps","entity-website-new-tab","highlight-dummy-org-child","frontend-links","search-user-email-by-username","set-network-name-equal-org-name","set-window-title"]));
+```
+
+Enable only `admin-console-link` in FP:
+
+```js
+localStorage.setItem("pdbFpConsolidated.disabledModules", JSON.stringify(["fix-double-slashes","set-window-title","copy-record-data","copy-user-roles"]));
+```
+
+Enable only `admin-console-link` and `copy-record-data` in FP:
+
+```js
+localStorage.setItem("pdbFpConsolidated.disabledModules", JSON.stringify(["fix-double-slashes","set-window-title","copy-user-roles"]));
+```
+
+### Generic whitelist helper one-liners
+
+Set `enabled` to the module IDs you want active; each helper computes and stores all other known modules as disabled.
+
+CP generic helper:
+
+```js
+(() => { const all = ["copy-frontend-urls","facility-google-maps","entity-website-new-tab","highlight-dummy-org-child","frontend-links","search-user-email-by-username","set-network-name-equal-org-name","reset-network-information","set-window-title"]; const enabled = ["reset-network-information"]; localStorage.setItem("pdbCpConsolidated.disabledModules", JSON.stringify(all.filter((id) => !enabled.includes(id)))); })();
+```
+
+FP generic helper:
+
+```js
+(() => { const all = ["fix-double-slashes","set-window-title","admin-console-link","copy-record-data","copy-user-roles"]; const enabled = ["admin-console-link"]; localStorage.setItem("pdbFpConsolidated.disabledModules", JSON.stringify(all.filter((id) => !enabled.includes(id)))); })();
+```
+
 
 ### Legacy CP scripts
 

--- a/user.js/peeringdb-cp-consolidated-tools.meta.js
+++ b/user.js/peeringdb-cp-consolidated-tools.meta.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         PeeringDB CP - Consolidated Tools
 // @namespace    https://www.peeringdb.com/cp/
-// @version      1.0.35.20260223
+// @version      1.0.40.20260302
 // @description  Consolidated CP userscript with strict route-isolated modules for facility/network/user/entity workflows
 // @author       <chriztoffer@peeringdb.com>
 // @match        https://www.peeringdb.com/cp/peeringdb_server/*/*/change/*

--- a/user.js/peeringdb-cp-consolidated-tools.meta.js
+++ b/user.js/peeringdb-cp-consolidated-tools.meta.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         PeeringDB CP - Consolidated Tools
 // @namespace    https://www.peeringdb.com/cp/
-// @version      1.0.42.20260303
+// @version      1.0.49.20260315
 // @description  Consolidated CP userscript with strict route-isolated modules for facility/network/user/entity workflows
 // @author       <chriztoffer@peeringdb.com>
 // @match        https://www.peeringdb.com/cp/peeringdb_server/*/*/change/*

--- a/user.js/peeringdb-cp-consolidated-tools.meta.js
+++ b/user.js/peeringdb-cp-consolidated-tools.meta.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         PeeringDB CP - Consolidated Tools
 // @namespace    https://www.peeringdb.com/cp/
-// @version      1.0.40.20260302
+// @version      1.0.42.20260303
 // @description  Consolidated CP userscript with strict route-isolated modules for facility/network/user/entity workflows
 // @author       <chriztoffer@peeringdb.com>
 // @match        https://www.peeringdb.com/cp/peeringdb_server/*/*/change/*

--- a/user.js/peeringdb-cp-consolidated-tools.user.js
+++ b/user.js/peeringdb-cp-consolidated-tools.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         PeeringDB CP - Consolidated Tools
 // @namespace    https://www.peeringdb.com/cp/
-// @version      1.0.40.20260302
+// @version      1.0.42.20260303
 // @description  Consolidated CP userscript with strict route-isolated modules for facility/network/user/entity workflows
 // @author       <chriztoffer@peeringdb.com>
 // @match        https://www.peeringdb.com/cp/peeringdb_server/*/*/change/*
@@ -321,11 +321,12 @@
    * Necessity: Uses multiple fallbacks to handle Django admin version variations.
    */
   function getToolbarList() {
-    return (
+    const toolbar = (
       qs("#grp-content-title > ul.grp-object-tools:not([data-pdb-cp-toolbar-row]):not([data-pdb-cp-action])") ||
       qs("#grp-content-title > ul.grp-object-tools") ||
       qs("#grp-content-title > ul")
     );
+    return toolbar;
   }
 
   /**
@@ -387,17 +388,29 @@
     a.id = id;
     a.href = href;
     a.textContent = label;
+    a.style.cursor = "pointer";
 
     if (target) {
       a.target = target;
     }
 
-    if (typeof onClick === "function") {
-      a.addEventListener("click", (event) => {
+    a.addEventListener("click", (event) => {
+      if (typeof onClick === "function") {
         event.preventDefault();
         onClick(event);
-      });
-    }
+        return;
+      }
+
+      if (href && href !== "#") {
+        event.preventDefault();
+        const resolvedUrl = new URL(href, window.location.origin).toString();
+        if (target && target !== "_self") {
+          window.open(resolvedUrl, target, "noopener");
+        } else {
+          window.location.href = resolvedUrl;
+        }
+      }
+    });
 
     li.appendChild(a);
 
@@ -495,6 +508,7 @@
     button.id = id;
     button.href = "#";
     button.textContent = label;
+    button.style.cursor = "pointer";
 
     if (typeof onClick === "function") {
       button.addEventListener("click", (event) => {
@@ -1396,9 +1410,7 @@
    * Runs the complete initialization sequence for consolidated tools.
    * Purpose: Parse route, dispatch modules, and enforce button order on current page.
    * Necessity: Single entry point for all initialization logic; ensures modules run before layout.
-   * Sets isInitRunning flag to prevent duplicate initialization during mutations.
    */
-  let isInitRunning = false;
   function runConsolidatedInit() {
     const ctx = getRouteContext();
 
@@ -1406,61 +1418,14 @@
       return;
     }
 
-    isInitRunning = true;
-    try {
-      cleanupLegacyPrimaryActionRow();
-      dispatchModules(ctx);
-      enforceToolbarButtonOrder(ctx);
-    } finally {
-      isInitRunning = false;
-    }
-  }
-
-  /**
-   * Schedules initialization to run on next animation frame, preventing duplicates.
-   * Purpose: Debounce repeated mutation events into a single initialization.
-   * Necessity: DOM mutations can fire many times per millisecond; this batches them into
-   * one operation to avoid redundant module calls and button reordering.
-   */
-  let initScheduled = false;
-  function scheduleConsolidatedInit() {
-    // Prevent triggering while modules are actively running (to avoid duplicate DOM insertions)
-    if (initScheduled || isInitRunning) return;
-    initScheduled = true;
-
-    requestAnimationFrame(() => {
-      initScheduled = false;
-      runConsolidatedInit();
-    });
-  }
-
-  /**
-   * Bootstrap the consolidated init system and attach event listeners.
-   * Purpose: Initialize the script on page load or immediately if DOM is ready.
-   * Necessity: Entry point that hooks into DOMContentLoaded and DOM mutations to detect
-   * when init should run. Sets up MutationObserver for AJAX/PJAX page navigation.
-   */
-  function bootstrapConsolidatedInit() {
-    scheduleConsolidatedInit();
-
-    window.addEventListener("popstate", scheduleConsolidatedInit);
-    window.addEventListener("hashchange", scheduleConsolidatedInit);
-
-    if (document.body) {
-      const observer = new MutationObserver(() => {
-        // Only allow re-init triggered by MutationObserver if not already running
-        if (!isInitRunning) {
-          scheduleConsolidatedInit();
-        }
-      });
-
-      observer.observe(document.body, { childList: true, subtree: true });
-    }
+    cleanupLegacyPrimaryActionRow();
+    dispatchModules(ctx);
+    enforceToolbarButtonOrder(ctx);
   }
 
   if (document.readyState === "loading") {
-    document.addEventListener("DOMContentLoaded", bootstrapConsolidatedInit, { once: true });
+    document.addEventListener("DOMContentLoaded", runConsolidatedInit, { once: true });
   } else {
-    bootstrapConsolidatedInit();
+    runConsolidatedInit();
   }
 })();

--- a/user.js/peeringdb-cp-consolidated-tools.user.js
+++ b/user.js/peeringdb-cp-consolidated-tools.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         PeeringDB CP - Consolidated Tools
 // @namespace    https://www.peeringdb.com/cp/
-// @version      1.0.42.20260303
+// @version      1.0.49.20260315
 // @description  Consolidated CP userscript with strict route-isolated modules for facility/network/user/entity workflows
 // @author       <chriztoffer@peeringdb.com>
 // @match        https://www.peeringdb.com/cp/peeringdb_server/*/*/change/*
@@ -37,6 +37,36 @@
     "internetexchange",
     "campus",
   ]); 
+  const COPY_FIELD_DENY_LABELS = new Set([
+    "logo",
+    "manual ix-f import request",
+    "manual ix-f import status",
+    "status",
+    "social media",
+    "ixf import request user",
+    "number of facilities at this exchange",
+    "number of networks at this exchange",
+    "version",
+    "ixf import history",
+    "ix-f network count",
+    "unicast ipv4",
+    "unicast ipv6",
+    "multicast",
+    "ix-f member export url visibility",
+    "id",
+    "ixf ixp import enabled",
+    "ix-f error",
+    "ix-f sent ips for unsupported protocol",
+    "ixf import attempt info",
+  ]);
+  const COPY_FIELD_CONDITIONAL_EMPTY_LABELS = new Set([
+    "technical phone",
+    "policy phone",
+    "sales phone",
+    "technical email",
+    "policy email",
+    "sales email",
+  ]);
 
   /**
    * Retrieves the set of disabled module IDs from localStorage.
@@ -729,6 +759,214 @@
   }
 
   /**
+   * Temporarily changes copy-icon button text then reverts after a delay.
+   * Purpose: Give immediate feedback for field-level copy actions.
+   * Necessity: Field copy buttons are icon-only by default and need success confirmation.
+   */
+  function pulseCopyIconButton(button, successLabel = "Copied") {
+    if (!button) return;
+
+    const original = button.textContent || "";
+    button.textContent = successLabel;
+    setTimeout(() => {
+      button.textContent = original;
+    }, 1000);
+  }
+
+  /**
+   * Ensures copy button CSS is available for field-level copy buttons.
+   * Purpose: Keep button visuals consistent and lightweight without external CSS dependencies.
+   * Necessity: The userscript runs in-page and must inject styles itself.
+   */
+  function ensureFieldCopyButtonStyles() {
+    const styleId = `${MODULE_PREFIX}CopyFieldStyle`;
+    if (document.getElementById(styleId)) return;
+
+    const style = document.createElement("style");
+    style.id = styleId;
+    style.textContent = `
+      .${MODULE_PREFIX}CopyFieldButton {
+        float: right;
+        margin-left: 6px;
+        border: 1px solid #d7d7d7;
+        border-radius: 3px;
+        background: #f9f9f9;
+        color: #444;
+        font-size: 11px;
+        line-height: 1.4;
+        padding: 0 6px;
+        cursor: pointer;
+      }
+      .${MODULE_PREFIX}CopyFieldButton:hover {
+        background: #efefef;
+      }
+    `;
+    document.head.appendChild(style);
+  }
+
+  /**
+   * Normalizes text copied from rendered field contents.
+   * Purpose: Remove excessive whitespace while preserving readable one-line output.
+   * Necessity: Rendered HTML often contains line breaks and spacing artifacts.
+   */
+  function normalizeRenderedCopyText(text) {
+    return String(text || "")
+      .replace(/\u00a0/g, " ")
+      .replace(/\s+/g, " ")
+      .trim();
+  }
+
+  /**
+   * Finds the field label text for a value container.
+   * Purpose: Support field-level filtering rules by human-visible label.
+   * Necessity: Some CP rows are metadata or helper rows and should not get copy icons.
+   */
+  function getFieldLabelText(valueCell) {
+    const row = valueCell?.closest(".form-row");
+    if (!row) return "";
+
+    const label = qs(".c-1 label", row) || qs(".c-1", row);
+    return normalizeRenderedCopyText(label?.textContent || "").toLowerCase();
+  }
+
+  /**
+   * Resolves best non-help data value from direct controls inside a field value cell.
+   * Purpose: Distinguish actual field data from explanatory helper text.
+   * Necessity: Prevents copy buttons from appearing when only help text is present.
+   */
+  function getDirectFieldDataValue(valueCell) {
+    if (!valueCell) return "";
+
+    const readonly = qs(".grp-readonly", valueCell);
+    if (readonly) {
+      return normalizeRenderedCopyText(readonly.textContent || "");
+    }
+
+    const select = qs("select", valueCell);
+    if (select) {
+      const selectedOptions = Array.from(select.selectedOptions || []);
+      const selectedText = selectedOptions
+        .map((option) => normalizeRenderedCopyText(option.textContent || option.value || ""))
+        .filter(Boolean)
+        .join(", ");
+      if (selectedText) return selectedText;
+    }
+
+    const textarea = qs("textarea", valueCell);
+    if (textarea) {
+      const value = normalizeRenderedCopyText(textarea.value || textarea.textContent || "");
+      if (value) return value;
+    }
+
+    const input = qs("input:not([type='hidden']):not([type='button']):not([type='submit']):not([type='reset']):not([type='file'])", valueCell);
+    if (input) {
+      const inputType = String(input.getAttribute("type") || "text").toLowerCase();
+      if (inputType === "checkbox" || inputType === "radio") {
+        return input.checked ? "true" : "false";
+      }
+
+      const value = normalizeRenderedCopyText(input.value || "");
+      if (value) return value;
+    }
+
+    const anchor = qs("a[href^='http://'], a[href^='https://']", valueCell);
+    if (anchor) {
+      const href = normalizeRenderedCopyText(anchor.getAttribute("href") || "");
+      if (href) return href;
+    }
+
+    return "";
+  }
+
+  /**
+   * Determines whether a value container should receive a copy button.
+   * Purpose: Exclude helper/metadata/lookup-only rows while keeping real data fields copiable.
+   * Necessity: Avoids noisy icons on rows that do not represent useful copyable values.
+   */
+  function shouldAttachCopyButtonToValueCell(valueCell) {
+    if (!valueCell) return false;
+
+    const labelText = getFieldLabelText(valueCell);
+    if (COPY_FIELD_DENY_LABELS.has(labelText)) return false;
+
+    const directValue = getDirectFieldDataValue(valueCell);
+    const isConditionalEmptyField = COPY_FIELD_CONDITIONAL_EMPTY_LABELS.has(labelText);
+    if (isConditionalEmptyField && !directValue) return false;
+
+    if (qs("input[type='file']", valueCell)) return false;
+
+    if (qs(".grp-help", valueCell) && !qs("input, textarea, select, .grp-readonly", valueCell)) {
+      return false;
+    }
+
+    const hasReadonly = Boolean(qs(".grp-readonly", valueCell));
+    const hasDataInput = Boolean(
+      qs("input:not([type='hidden']):not([type='button']):not([type='submit']):not([type='reset']):not([type='file']), textarea, select", valueCell),
+    );
+    const hasPublicLink = Boolean(qs("a[href^='http://'], a[href^='https://']", valueCell));
+
+    return hasReadonly || hasDataInput || hasPublicLink;
+  }
+
+  /**
+   * Resolves the best rendered value from a Django admin field value container.
+   * Purpose: Prefer human-visible values (grp-readonly, selected option labels) over raw markup.
+   * Necessity: Different field types render values differently in CP forms and inline forms.
+   */
+  function getRenderedFieldValue(container) {
+    if (!container) return "";
+
+    const directValue = getDirectFieldDataValue(container);
+    if (directValue) return directValue;
+
+    const clone = container.cloneNode(true);
+    qsa(".grp-help", clone).forEach((help) => help.remove());
+    qsa(`button.${MODULE_PREFIX}CopyFieldButton`, clone).forEach((button) => button.remove());
+    return normalizeRenderedCopyText(clone.textContent || "");
+  }
+
+  /**
+   * Adds a copy icon button to each rendered form value container.
+   * Purpose: Make every visible field value directly copiable from the CP UI.
+   * Necessity: Admin workflows often require copying readonly values such as Prefixes.
+   */
+  function addCopyButtonsToRenderedFields() {
+    ensureFieldCopyButtonStyles();
+
+    qsa(".form-row .c-2").forEach((valueCell) => {
+      if (valueCell.hasAttribute("data-pdb-cp-copy-bound")) return;
+      if (!shouldAttachCopyButtonToValueCell(valueCell)) return;
+
+      const initialValue = getRenderedFieldValue(valueCell);
+      if (!initialValue) return;
+
+      valueCell.setAttribute("data-pdb-cp-copy-bound", "1");
+
+      const button = document.createElement("button");
+      button.type = "button";
+      button.className = `${MODULE_PREFIX}CopyFieldButton`;
+      button.title = "Copy value";
+      button.setAttribute("aria-label", "Copy value");
+      button.textContent = "⧉";
+
+      button.addEventListener("click", async (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+
+        const value = getRenderedFieldValue(valueCell);
+        if (!value) return;
+
+        const copied = await copyToClipboard(value);
+        if (copied) {
+          pulseCopyIconButton(button);
+        }
+      });
+
+      valueCell.appendChild(button);
+    });
+  }
+
+  /**
    * Determines the frontend URL path for a CP entity (network, carrier, ix).
    * Purpose: Generate correct copy-to-clipboard URL for the current entity type.
    * Necessity: Different entity types map to different URL paths.
@@ -1146,6 +1384,14 @@
             }
           },
         });
+      },
+    },
+    {
+      id: "copy-rendered-field-values",
+      match: (ctx) => ctx.isEntityChangePage,
+      preconditions: () => Boolean(qs(".form-row .c-2")),
+      run: () => {
+        addCopyButtonsToRenderedFields();
       },
     },
     {

--- a/user.js/peeringdb-cp-consolidated-tools.user.js
+++ b/user.js/peeringdb-cp-consolidated-tools.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         PeeringDB CP - Consolidated Tools
 // @namespace    https://www.peeringdb.com/cp/
-// @version      1.0.35.20260223
+// @version      1.0.40.20260302
 // @description  Consolidated CP userscript with strict route-isolated modules for facility/network/user/entity workflows
 // @author       <chriztoffer@peeringdb.com>
 // @match        https://www.peeringdb.com/cp/peeringdb_server/*/*/change/*
@@ -17,6 +17,18 @@
 
   const MODULE_PREFIX = "pdbCpConsolidated";
   const DUMMY_ORG_ID = 20525;
+  const DISABLED_MODULES_STORAGE_KEY = `${MODULE_PREFIX}.disabledModules`;
+  const USER_AGENT_STORAGE_KEY = `${MODULE_PREFIX}.userAgent`;
+  const SESSION_UUID_STORAGE_KEY = `${MODULE_PREFIX}.sessionUuid`;
+  const TRUSTED_DOMAINS_FOR_UA = [
+    "peeringdb.com",
+    "*.peeringdb.com",
+    "api.peeringdb.com",
+    "127.0.0.1",
+    "::1",
+    "localhost",
+  ];
+  const DEFAULT_REQUEST_USER_AGENT = "PeeringDB-Admincom-CP-Consolidated";
   const ENTITY_TYPES = new Set([
     "facility",
     "network",
@@ -25,6 +37,170 @@
     "internetexchange",
     "campus",
   ]); 
+
+  /**
+   * Retrieves the set of disabled module IDs from localStorage.
+   * Purpose: Allows individual modules to be toggled on/off without code changes.
+   * Necessity: Provides user-level module control for the modular architecture.
+   * Supports both JSON array and comma-separated formats for backward compatibility.
+   */
+  function getDisabledModules() {
+    const raw = String(window.localStorage?.getItem(DISABLED_MODULES_STORAGE_KEY) || "").trim();
+    if (!raw) return new Set();
+
+    try {
+      const parsed = JSON.parse(raw);
+      if (Array.isArray(parsed)) {
+        return new Set(parsed.map((item) => String(item || "").trim()).filter(Boolean));
+      }
+    } catch (_error) {
+      // fallback to comma-separated format
+    }
+
+    return new Set(
+      raw
+        .split(",")
+        .map((item) => String(item || "").trim())
+        .filter(Boolean),
+    );
+  }
+
+  /**
+   * Checks if a module is enabled (not in the disabled set).
+   * Purpose: Gate-keeper for module execution in dispatchModules().
+   * Necessity: Implements selective module control without removing code.
+   */
+  function isModuleEnabled(moduleId, disabledModules) {
+    if (!moduleId) return false;
+    return !disabledModules.has(moduleId);
+  }
+
+  /**
+   * Retrieves explicit or auto-computed User-Agent for this session.
+   * Purpose: Provide flexible UA configuration with fallback to trust-based generation.
+   * Necessity: Allows manual override via localStorage while auto-computing from domain trust.
+   */
+  function getCustomRequestUserAgent() {
+    const configured = String(window.localStorage?.getItem(USER_AGENT_STORAGE_KEY) || "").trim();
+    if (configured) return configured;
+    // Auto-compute trust-based UA if not explicitly configured
+    return buildTrustBasedUserAgent(window.location.hostname);
+  }
+
+  /**
+   * Generates or retrieves a persistent session UUID for the browser session.
+   * Purpose: Provides a unique identifier for correlating requests within a session.
+   * Necessity: Enables server-side analytics and request tracking without exposing device fingerprint.
+   * UUID persists across page reloads but is cleared when tab/session closes.
+   */
+  function getSessionUuid() {
+    const sessionKey = SESSION_UUID_STORAGE_KEY;
+    let uuid = window.sessionStorage?.getItem(sessionKey);
+    if (!uuid) {
+      uuid = `${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+      if (window.sessionStorage) {
+        window.sessionStorage.setItem(sessionKey, uuid);
+      }
+    }
+    return uuid;
+  }
+
+  /**
+   * Computes a stable client fingerprint from browser/device attributes.
+   * Purpose: Creates a privacy-preserving identifier for requests from untrusted domains.
+   * Necessity: Balances analytics tracking with user privacy for non-trusted networks.
+   * Returns a 16-character hex string derived from UA, platform, language, CPU count, memory.
+   */
+  function computeClientFingerprint() {
+    const parts = [
+      navigator.userAgent,
+      navigator.platform,
+      navigator.language,
+      navigator.hardwareConcurrency || "unknown",
+      navigator.deviceMemory || "unknown",
+    ].join("|");
+
+    let hash = 0;
+    for (let i = 0; i < parts.length; i++) {
+      const char = parts.charCodeAt(i);
+      hash = (hash << 5) - hash + char;
+      hash = hash & hash; // Convert to 32-bit integer
+    }
+    return Math.abs(hash).toString(16).padStart(16, "0").substr(0, 16);
+  }
+
+  /**
+   * Determines if a domain is in the trusted domain list.
+   * Purpose: Implement domain-based trust policy for User-Agent header generation.
+   * Necessity: Distinguishes between trusted (localhost, peeringdb.com) and untrusted domains
+   * to decide whether to use full browser info or privacy-preserving fingerprint.
+   * Also normalizes IPv6 URIs with bracket notation ([::1]) for transparent matching.
+   */
+  function isDomainTrusted(domain) {
+    if (!domain) return false;
+    // Normalize: trim, lowercase, and strip IPv6 URI brackets (e.g., [::1] → ::1)
+    let domainText = String(domain).trim().toLowerCase();
+    if (domainText.startsWith("[") && domainText.endsWith("]")) {
+      domainText = domainText.slice(1, -1);  // Strip IPv6 URI brackets
+    }
+    if (!domainText) return false;
+
+    for (const pattern of TRUSTED_DOMAINS_FOR_UA) {
+      const patternLower = pattern.toLowerCase();
+      if (patternLower === domainText) return true;
+
+      // Handle wildcard patterns like *.peeringdb.com
+      if (patternLower.startsWith("*.")) {
+        const baseDomain = patternLower.slice(2);
+        if (domainText === baseDomain || domainText.endsWith("." + baseDomain)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Constructs a User-Agent string based on domain trust level.
+   * Purpose: Provide contextual information to backend while respecting user privacy.
+   * Necessity: For trusted domains (development, peeringdb.com), includes browser/platform for debugging;
+   * for untrusted domains, uses fingerprint only to minimize data exposure.
+   * Includes session UUID in both cases for request correlation.
+   */
+  function buildTrustBasedUserAgent(domain) {
+    const isTrusted = isDomainTrusted(domain);
+    const sessionUuid = getSessionUuid();
+
+    if (isTrusted) {
+      // Full-detail UA for trusted domains (server-side context, logging, analytics)
+      const browserInfo = `${navigator.userAgent.split(" ").slice(-1)[0]} ${navigator.platform}`;
+      return `${DEFAULT_REQUEST_USER_AGENT} (${browserInfo} uuid/${sessionUuid})`;
+    }
+
+    // Privacy-preserving UA with fingerprint only for untrusted domains
+    const fingerprint = computeClientFingerprint();
+    return `${DEFAULT_REQUEST_USER_AGENT} (fingerprint/${fingerprint} uuid/${sessionUuid})`;
+  }
+
+  /**
+   * Constructs HTTP headers for Tampermonkey requests with User-Agent.
+   * Purpose: Centralize header building for all script-initiated requests.
+   * Necessity: Ensures consistent User-Agent and other important headers across all API calls.
+   */
+  function buildTampermonkeyRequestHeaders(baseHeaders = {}) {
+    const headers = { ...baseHeaders };
+    const configured = String(window.localStorage?.getItem(USER_AGENT_STORAGE_KEY) || "").trim();
+
+    // Use configured UA if explicitly set, otherwise auto-compute from domain trust
+    const userAgent =
+      configured ||
+      buildTrustBasedUserAgent(window.location.hostname);
+
+    if (userAgent) {
+      headers["User-Agent"] = userAgent;
+    }
+    return headers;
+  }
 
   function getRouteContext() {
     const path = window.location.pathname.replace(/(^\/|\/$)/g, "").split("/");
@@ -41,6 +217,12 @@
     };
   }
 
+  /**
+   * Convenience wrapper for querySelector.
+   * Purpose: Reduce boilerplate for DOM querying throughout the script.
+   * Necessity: Used extensively for finding form fields and toolbar elements.
+   * Wraps in try-catch to safely return null on selector errors.
+   */
   function qs(selector, root = document) {
     try {
       return root.querySelector(selector);
@@ -49,6 +231,11 @@
     }
   }
 
+  /**
+   * Convenience wrapper for querySelectorAll returning an array.
+   * Purpose: Reduce boilerplate for finding multiple DOM elements.
+   * Necessity: Used for inline sets, dynamic forms, and multi-element operations.
+   */
   function qsa(selector, root = document) {
     try {
       return Array.from(root.querySelectorAll(selector));
@@ -57,6 +244,11 @@
     }
   }
 
+  /**
+   * Retrieves trimmed value from form input elements (input, select, textarea).
+   * Purpose: Unified value extraction that handles both .value property and data attributes.
+   * Necessity: Normalizes form field reading across different input types in Django admin forms.
+   */
   function getInputValue(selector) {
     const element = qs(selector);
     if (!element) return "";
@@ -68,6 +260,11 @@
     return String(element.getAttribute("value") || "").trim();
   }
 
+  /**
+   * Sets value on form input elements with consistent synchronization.
+   * Purpose: Unified value assignment that updates both .value and attributes.
+   * Necessity: Ensures form frameworks recognize the change (defaultValue for reset detection).
+   */
   function setInputValue(selector, value) {
     const element = qs(selector);
     if (!element) return false;
@@ -84,6 +281,11 @@
     return true;
   }
 
+  /**
+   * Sets network name field value with proper change event firing.
+   * Purpose: Ensure form validation and dependency updates trigger when name changes.
+   * Necessity: Django admin forms monitor change events; manual setting requires event dispatch.
+   */
   function setNetworkNameValue(value) {
     const input = document.getElementById("id_name");
     if (!input) return false;
@@ -97,6 +299,12 @@
     return true;
   }
 
+  /**
+   * Generates a deterministic ASN-based network name with optional suffix.
+   * Purpose: Provide sensible fallback names for networks when org lookup fails.
+   * Necessity: Required field can't be empty; ASN is stable and visible on network pages.
+   * Includes '#deleted' suffix for networks in deleted status.
+   */
   function getDeterministicNetworkFallbackName(asn, networkId, suffix = "") {
     const cleaned = String(asn || "").replace(/^AS/i, "").trim();
     const parsedAsn = Number.parseInt(cleaned, 10);
@@ -107,6 +315,11 @@
     return `AS${networkId}${suffix}`;
   }
 
+  /**
+   * Retrieves the primary toolbar list from the page header.
+   * Purpose: Centralize toolbar element selection with fallback selectors.
+   * Necessity: Uses multiple fallbacks to handle Django admin version variations.
+   */
   function getToolbarList() {
     return (
       qs("#grp-content-title > ul.grp-object-tools:not([data-pdb-cp-toolbar-row]):not([data-pdb-cp-action])") ||
@@ -115,6 +328,11 @@
     );
   }
 
+  /**
+   * Removes deprecated primary action row from legacy versions.
+   * Purpose: Clean up stale DOM elements from previous script versions.
+   * Necessity: Ensures backward compatibility when script updates; prevents duplicate action rows.
+   */
   function cleanupLegacyPrimaryActionRow() {
     const legacyRow = qs(`#${MODULE_PREFIX}PrimaryActionRow`);
     if (!legacyRow) return;
@@ -122,6 +340,12 @@
     legacyRow.remove();
   }
 
+  /**
+   * Applies calculated vertical offset to secondary action row.
+   * Purpose: Prevent overlap between primary toolbar and secondary action row.
+   * Necessity: Secondary row appears below primary toolbar; must account for toolbar height
+   * which varies by content. Uses BoundingClientRect to detect actual overlap.
+   */
   function applySecondaryRowVerticalOffset(row) {
     if (!row) return;
 
@@ -139,6 +363,12 @@
     row.style.marginTop = `${computedOffset}px`;
   }
 
+  /**
+   * Creates and inserts a toolbar action button (link) into the primary toolbar.
+   * Purpose: Standardized way to add custom buttons (Google Maps, Frontend links, etc.).
+   * Necessity: Ensures consistent styling, idempotency (prevents duplicates), and placement.
+   * Marks buttons with data-pdb-cp-action attribute for reordering and identification.
+   */
   function addToolbarAction({ id, label, href = "#", onClick, target = null, insertLeft = false }) {
     if (!id) return null;
 
@@ -191,6 +421,12 @@
     return a;
   }
 
+  /**
+   * Creates or retrieves secondary action row below primary toolbar.
+   * Purpose: Provide a second row for less-critical actions (Copy URL, Copy Org URL).
+   * Necessity: Prevents primary toolbar overcrowding while keeping actions accessible.
+   * Applies vertical offset dynamically and handles resize events.
+   */
   function getOrCreateSecondaryActionRow() {
     const contentTitle = qs("#grp-content-title");
     if (!contentTitle) return null;
@@ -232,6 +468,11 @@
     return row;
   }
 
+  /**
+   * Creates and appends a button to the secondary action row.
+   * Purpose: Add custom actions to secondary row with consistent styling.
+   * Necessity: Secondary row actions need inline-block styling and spacing different from primary toolbar.
+   */
   function addSecondaryActionButton({ id, label, onClick }) {
     const row = getOrCreateSecondaryActionRow();
     if (!row || !id) return null;
@@ -267,6 +508,11 @@
     return button;
   }
 
+  /**
+   * Tests if a DOM element matches a given priority (CSS selector or function).
+   * Purpose: Support flexible matching in reorderChildrenByPriority (handles strings and predicates).
+   * Necessity: Enables both CSS-based matching and custom function-based matching in one API.
+   */
   function isPriorityMatch(child, priority) {
     if (!child || !priority) return false;
 
@@ -285,6 +531,11 @@
     }
   }
 
+  /**
+   * Identifies if a toolbar item is the History button.
+   * Purpose: Handle History button specially in reordering (position it before custom actions).
+   * Necessity: History button is Django admin native; needs position priority awareness.
+   */
   function isHistoryToolbarItem(child) {
     if (!child || child.hasAttribute("data-pdb-cp-action")) return false;
 
@@ -296,6 +547,12 @@
     return href.includes("/history/") || text === "history";
   }
 
+  /**
+   * Reorders children of a container according to priority list.
+   * Purpose: Establish deterministic button order (Frontend before Org links, History before custom).
+   * Necessity: Ensures consistent UI layout across page variations and module load orders.
+   * Unmatched children stay in original order at the end.
+   */
   function reorderChildrenByPriority(container, priorities) {
     if (!container || !Array.isArray(priorities) || priorities.length === 0) return;
 
@@ -319,6 +576,12 @@
     ordered.forEach((child) => container.appendChild(child));
   }
 
+  /**
+   * Enforces deterministic action button order in both primary and secondary toolbars (network only).
+   * Purpose: Coordinate reordering of all network page toolbar buttons.
+   * Necessity: Network pages have most custom actions; reordering provides consistent UX.
+   * For other entity types, no special ordering applied (preserves natural order).
+   */
   function enforceToolbarButtonOrder(ctx) {
     if (!ctx?.isEntityChangePage || ctx.entity !== "network") return;
 
@@ -343,6 +606,12 @@
     }
   }
 
+  /**
+   * Fetches organization name from PeeringDB API by organization ID.
+   * Purpose: Resolve human-readable org names for network initialization.
+   * Necessity: Network name should match org name; API lookup is more reliable than manual lookup.
+   * Returns null on network error or missing data (graceful degradation).
+   */
   async function getOrganizationName(orgId) {
     if (!orgId) return null;
 
@@ -357,6 +626,11 @@
     }
   }
 
+  /**
+   * Programmatically clicks the "Save and continue editing" button.
+   * Purpose: Auto-submit form after automated edits (Reset Information, Update Name).
+   * Necessity: Script-driven form changes need programmatic submission; improves UX.
+   */
   function clickSaveAndContinue() {
     const button =
       qs("#network_form input[name='_continue']") ||
@@ -368,6 +642,11 @@
     return true;
   }
 
+  /**
+   * Prompts user to confirm dangerous network reset operation.
+   * Purpose: Prevent accidental data loss from Reset Information action.
+   * Necessity: Shows user which network is being reset (by ID, ASN, name) for confirmation.
+   */
   function confirmDangerousReset(asn, networkName, networkId) {
     const asnLabel = String(asn || "").trim();
     const nameLabel = String(networkName || "").trim();
@@ -386,6 +665,11 @@
     );
   }
 
+  /**
+   * Copies text to clipboard with modern and fallback implementations.
+   * Purpose: Enable "Copy URL" actions for user convenience.
+   * Necessity: Handles browsers with and without Clipboard API support.
+   */
   async function copyToClipboard(text) {
     const value = String(text || "");
     if (!value) return false;
@@ -415,6 +699,11 @@
     }
   }
 
+  /**
+   * Temporarily changes button text then reverts after a delay.
+   * Purpose: Provide user feedback that copy action succeeded.
+   * Necessity: "Copied" feedback improves UX for copy-to-clipboard buttons.
+   */
   function pulseToolbarButton(anchor, successLabel = "Copied") {
     if (!anchor) return;
 
@@ -425,6 +714,11 @@
     }, 1000);
   }
 
+  /**
+   * Determines the frontend URL path for a CP entity (network, carrier, ix).
+   * Purpose: Generate correct copy-to-clipboard URL for the current entity type.
+   * Necessity: Different entity types map to different URL paths.
+   */
   function getCopyNetworkFrontendPath(ctx) {
     if (ctx.entity === "carrier") {
       return `/carrier/${ctx.entityId}`;
@@ -437,15 +731,30 @@
     return `/net/${ctx.entityId}`;
   }
 
+  /**
+   * Retrieves currently selected status from the status dropdown.
+   * Purpose: Determine if network/entity is marked as deleted.
+   * Necessity: Used to add " #deleted" suffix to entity names for deleted records.
+   */
   function getSelectedStatus() {
     const option = qs("#id_status > option:checked") || qs("#id_status > option[selected]");
     return option ? String(option.getAttribute("value") || "") : "";
   }
 
+  /**
+   * Generates a name suffix for deleted networks.
+   * Purpose: Append " #networkId" to network name if status is "deleted".
+   * Necessity: Marks deleted networks visibly; required for duplicate network handling.
+   */
   function getNameSuffixForDeletedNetwork(netId) {
     return getSelectedStatus() === "deleted" ? ` #${netId}` : "";
   }
 
+  /**
+   * Marks inline form rows (POCs, netfacs, netixlans) for deletion if status = 'deleted'.
+   * Purpose: Clean up stale inline items when network status is deleted.
+   * Necessity: Automatic cleanup prevents orphaned POCs/facilities when network is marked deleted.
+   */
   function clickDeleteHandlersForInlineSet(inlineSetPrefix) {
     qsa(`div.form-row.grp-dynamic-form[id^='${inlineSetPrefix}']`).forEach((row) => {
       if (row.id === `${inlineSetPrefix}-empty`) return;
@@ -478,6 +787,11 @@
     });
   }
 
+  /**
+   * Marks all deleted-status inline items for deletion across all inline sets.
+   * Purpose: Centralize deletion of all stale inline items (POCs, facilities, ixlans).
+   * Necessity: Ensures consistent cleanup of deleted network members across all relation types.
+   */
   function markDeletedNetworkInlinesForDeletion() {
     clickDeleteHandlersForInlineSet("poc_set");
     clickDeleteHandlersForInlineSet("netfac_set");
@@ -485,6 +799,12 @@
   }
 
   // RDAP client module (fully isolated from feature modules)
+  /**
+   * Isolated RDAP AutoNum client for resolving organization names by ASN.
+   * Purpose: Provide fallback organization name lookup via IANA RDAP bootstrap.
+   * Necessity: When org lookup fails (org_id invalid), RDAP provides ASN-based name resolution.
+   * Bootstraps RDAP service URLs from IANA registry with 6-hour TTL cache.
+   */
   const rdapAutnumClient = (() => {
     const BOOTSTRAP_ASN_URL = "https://data.iana.org/rdap/asn.json"; // RFC 9224 bootstrap registry
     const RDAP_ACCEPT_HEADER = "application/rdap+json, application/json;q=0.8";
@@ -495,23 +815,38 @@
       payload: null,
     };
 
+    /**
+     * Parses and validates ASN from string input.
+     * Purpose: Convert ASN string (with or without "AS" prefix) to integer.
+     * Necessity: Validates ASN format before RDAP queries.
+     */
     function parseAsn(value) {
       const number = Number.parseInt(String(value || "").trim(), 10);
       if (!Number.isInteger(number) || number <= 0) return null;
       return number;
     }
 
+    /**
+     * Normalizes RDAP base URL by removing trailing slashes.
+     * Purpose: Create consistent URLs for RDAP endpoint construction.
+     * Necessity: Base URLs may have trailing slashes; normalization prevents double slashes.
+     */
     function normalizeBaseUrl(baseUrl) {
       if (!baseUrl) return null;
       return String(baseUrl).replace(/\/+$/, "");
     }
 
+    /**
+     * Fetches JSON from URL with proper headers and error handling.
+     * Purpose: Unified JSON request helper for RDAP API calls.
+     * Necessity: Uses Tampermonkey's GM_xmlhttpRequest for cross-origin CORS-free requests.
+     */
     function requestJson(url) {
       return new Promise((resolve) => {
         GM_xmlhttpRequest({
           method: "GET",
           url,
-          headers: { Accept: RDAP_ACCEPT_HEADER },
+          headers: buildTampermonkeyRequestHeaders({ Accept: RDAP_ACCEPT_HEADER }),
           onload: (response) => {
             if (response.status >= 200 && response.status < 300) {
               try {
@@ -528,6 +863,12 @@
       });
     }
 
+    /**
+     * Fetches or retrieves cached IANA RDAP bootstrap registry.
+     * Purpose: Get list of RDAP service providers for various ASN ranges.
+     * Necessity: Bootstrap registry maps ASN ranges to RDAP endpoints; 6-hour TTL cache
+     * reduces load on IANA servers. Required before any RDAP autnum queries.
+     */
     async function getBootstrap() {
       const now = Date.now();
       if (
@@ -546,6 +887,12 @@
       return payload;
     }
 
+    /**
+     * Tests if ASN falls within a hyphen-separated range.
+     * Purpose: Determine if given ASN matches a bootstrap range.
+     * Necessity: Bootstrap registry uses ranges like "1-23456"; membership test needed
+     * to find correct RDAP endpoint provider.
+     */
     function isAsnInRange(asn, rangeText) {
       const range = String(rangeText || "").trim();
       if (!range) return false;
@@ -558,6 +905,11 @@
       return asn >= parts[0] && asn <= parts[1];
     }
 
+    /**
+     * Finds the appropriate RDAP base URL for an ASN from bootstrap registry.
+     * Purpose: Look up correct RDAP service endpoint (RIPE, APNIC, ARIN, etc.) by ASN.
+     * Necessity: Different RIRs operate different RDAP endpoints; bootstrap maps ASNs to regions.
+     */
     function getAutnumBaseUrlFromBootstrap(bootstrap, asn) {
       const services = Array.isArray(bootstrap?.services) ? bootstrap.services : [];
 
@@ -574,6 +926,11 @@
       return null;
     }
 
+    /**
+     * Fetches RDAP AutNum record for a given ASN.
+     * Purpose: Retrieve organization and contact data from authoritative RDAP source.
+     * Necessity: RDAP provides RFC 7483 standard organization data including vcard info.
+     */
     async function fetchAutnumRecord(asn) {
       const bootstrap = await getBootstrap();
       const baseUrl = getAutnumBaseUrlFromBootstrap(bootstrap, asn);
@@ -582,6 +939,11 @@
       return requestJson(`${baseUrl}/autnum/${asn}`);
     }
 
+    /**
+     * Extracts property value from RDAP vCard array.
+     * Purpose: Safely retrieve vCard properties (fn=full name, org=organization).
+     * Necessity: vCard is RFC 6350 format array; property names are lowercase.
+     */
     function getVcardProperty(vcardArray, propertyName) {
       const cards = Array.isArray(vcardArray?.[1]) ? vcardArray[1] : [];
       const property = cards.find(
@@ -592,6 +954,12 @@
       return String(property[3] || "").trim();
     }
 
+    /**
+     * Recursively collects entity candidates from RDAP payload with scoring.
+     * Purpose: Build ranked list of organization name candidates.
+     * Necessity: RDAP can have multiple entities (registrant, admin, billing, etc.);
+     * scoring prioritizes registrant > administrative roles, organizations > people.
+     */
     function collectEntityCandidates(entities, candidates = [], depth = 0) {
       if (!Array.isArray(entities)) return candidates;
 
@@ -622,6 +990,11 @@
       return candidates;
     }
 
+    /**
+     * Extracts best organization name from RDAP AutoNum payload.
+     * Purpose: Determine most likely official name for network entity.
+     * Necessity: Collects entities, scores by role/type, returns highest-scored name.
+     */
     function resolveOrganizationNameFromAutnumPayload(payload) {
       const candidates = collectEntityCandidates(payload?.entities, []);
       if (!candidates.length) return null;
@@ -630,6 +1003,12 @@
       return candidates[0]?.value || null;
     }
 
+    /**
+     * Public API: Resolves organization name for ASN via RDAP lookup.
+     * Purpose: Fallback organization name resolution when direct org ID lookup fails.
+     * Necessity: Enables Reset Information to work even if org_id field is invalid/empty.
+     * Returns null on network error or missing organization data (graceful degradation).
+     */
     async function resolveOrganizationNameByAsn(asnInput) {
       const asn = parseAsn(asnInput);
       if (!asn) return null;
@@ -656,6 +1035,12 @@
     };
   })();
 
+  /**
+   * Executes comprehensive network reset clearing all fields to defaults.
+   * Purpose: Prepare network record for re-initialization (especially for RDAP lookups).
+   * Necessity: Reset Information action clears stale data before re-populating from API sources.
+   * Preserves critical fields (name handles separately) and marks deleted inlines for removal.
+   */
   function runNetworkResetActions() {
     const formArea = qs("#network_form > div > fieldset:nth-child(2)");
     if (!formArea) return;
@@ -774,7 +1159,7 @@
           id: `${MODULE_PREFIX}GoogleMaps`,
           label: "Google Maps",
           href,
-          target: query || "_blank",
+          target: "_blank",
         });
       },
     },
@@ -986,9 +1371,18 @@
     },
   ];
 
+  /**
+   * Executes all enabled modules that match the current route context.
+   * Purpose: Central dispatcher that activates modules for the current page.
+   * Necessity: Implements modular architecture; checks both enabled status and page match
+   * before running each module. Catches and logs errors to prevent cascade failures.
+   */
   function dispatchModules(ctx) {
+    const disabledModules = getDisabledModules();
+
     modules.forEach((module) => {
       try {
+        if (!isModuleEnabled(module.id, disabledModules)) return;
         if (!module.match(ctx)) return;
         if (typeof module.preconditions === "function" && !module.preconditions(ctx)) return;
         module.run(ctx);
@@ -998,15 +1392,75 @@
     });
   }
 
-  const ctx = getRouteContext();
+  /**
+   * Runs the complete initialization sequence for consolidated tools.
+   * Purpose: Parse route, dispatch modules, and enforce button order on current page.
+   * Necessity: Single entry point for all initialization logic; ensures modules run before layout.
+   * Sets isInitRunning flag to prevent duplicate initialization during mutations.
+   */
+  let isInitRunning = false;
+  function runConsolidatedInit() {
+    const ctx = getRouteContext();
 
-  // Hard route safety: consolidated script should never run outside intended CP entity change pages.
-  if (!ctx.isCp || !ctx.isEntityChangePage) {
-    return;
+    if (!ctx.isCp || !ctx.isEntityChangePage) {
+      return;
+    }
+
+    isInitRunning = true;
+    try {
+      cleanupLegacyPrimaryActionRow();
+      dispatchModules(ctx);
+      enforceToolbarButtonOrder(ctx);
+    } finally {
+      isInitRunning = false;
+    }
   }
 
-  cleanupLegacyPrimaryActionRow();
+  /**
+   * Schedules initialization to run on next animation frame, preventing duplicates.
+   * Purpose: Debounce repeated mutation events into a single initialization.
+   * Necessity: DOM mutations can fire many times per millisecond; this batches them into
+   * one operation to avoid redundant module calls and button reordering.
+   */
+  let initScheduled = false;
+  function scheduleConsolidatedInit() {
+    // Prevent triggering while modules are actively running (to avoid duplicate DOM insertions)
+    if (initScheduled || isInitRunning) return;
+    initScheduled = true;
 
-  dispatchModules(ctx);
-  enforceToolbarButtonOrder(ctx);
+    requestAnimationFrame(() => {
+      initScheduled = false;
+      runConsolidatedInit();
+    });
+  }
+
+  /**
+   * Bootstrap the consolidated init system and attach event listeners.
+   * Purpose: Initialize the script on page load or immediately if DOM is ready.
+   * Necessity: Entry point that hooks into DOMContentLoaded and DOM mutations to detect
+   * when init should run. Sets up MutationObserver for AJAX/PJAX page navigation.
+   */
+  function bootstrapConsolidatedInit() {
+    scheduleConsolidatedInit();
+
+    window.addEventListener("popstate", scheduleConsolidatedInit);
+    window.addEventListener("hashchange", scheduleConsolidatedInit);
+
+    if (document.body) {
+      const observer = new MutationObserver(() => {
+        // Only allow re-init triggered by MutationObserver if not already running
+        if (!isInitRunning) {
+          scheduleConsolidatedInit();
+        }
+      });
+
+      observer.observe(document.body, { childList: true, subtree: true });
+    }
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", bootstrapConsolidatedInit, { once: true });
+  } else {
+    bootstrapConsolidatedInit();
+  }
 })();

--- a/user.js/peeringdb-fp-consolidated-tools.meta.js
+++ b/user.js/peeringdb-fp-consolidated-tools.meta.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         PeeringDB FP - Consolidated Tools
 // @namespace    https://www.peeringdb.com/
-// @version      1.0.15.20260224
+// @version      1.0.20.20260302
 // @description  Consolidated FP userscript for PeeringDB frontend (Net/Org/Fac/IX/Carrier)
 // @author       <chriztoffer@peeringdb.com>
 // @match        https://www.peeringdb.com/*

--- a/user.js/peeringdb-fp-consolidated-tools.user.js
+++ b/user.js/peeringdb-fp-consolidated-tools.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         PeeringDB FP - Consolidated Tools
 // @namespace    https://www.peeringdb.com/
-// @version      1.0.15.20260224
+// @version      1.0.20.20260302
 // @description  Consolidated FP userscript for PeeringDB frontend (Net/Org/Fac/IX/Carrier)
 // @author       <chriztoffer@peeringdb.com>
 // @match        https://www.peeringdb.com/*
@@ -16,7 +16,184 @@
   "use strict";
 
   const MODULE_PREFIX = "pdbFpConsolidated";
+  const DISABLED_MODULES_STORAGE_KEY = `${MODULE_PREFIX}.disabledModules`;
+  const USER_AGENT_STORAGE_KEY = `${MODULE_PREFIX}.userAgent`;
+  const SESSION_UUID_STORAGE_KEY = `${MODULE_PREFIX}.sessionUuid`;
+  const TRUSTED_DOMAINS_FOR_UA = [
+    "peeringdb.com",
+    "*.peeringdb.com",
+    "api.peeringdb.com",
+    "127.0.0.1",
+    "::1",
+    "localhost",
+  ];
+  const DEFAULT_REQUEST_USER_AGENT = "PeeringDB-Admincom-FP-Consolidated";
 
+  /**
+   * Retrieves the set of disabled module IDs from localStorage.
+   * Purpose: Allows individual modules to be toggled on/off without code changes.
+   * Necessity: Provides user-level module control for the modular architecture.
+   * Supports both JSON array and comma-separated formats for backward compatibility.
+   */
+  function getDisabledModules() {
+    const raw = String(window.localStorage?.getItem(DISABLED_MODULES_STORAGE_KEY) || "").trim();
+    if (!raw) return new Set();
+
+    try {
+      const parsed = JSON.parse(raw);
+      if (Array.isArray(parsed)) {
+        return new Set(parsed.map((item) => String(item || "").trim()).filter(Boolean));
+      }
+    } catch (_error) {
+      // fallback to comma-separated format
+    }
+
+    return new Set(
+      raw
+        .split(",")
+        .map((item) => String(item || "").trim())
+        .filter(Boolean),
+    );
+  }
+
+  /**
+   * Checks if a module is enabled (not in the disabled set).
+   * Purpose: Gate-keeper for module execution in dispatchModules().
+   * Necessity: Implements selective module control without removing code.
+   */
+  function isModuleEnabled(moduleId, disabledModules) {
+    if (!moduleId) return false;
+    return !disabledModules.has(moduleId);
+  }
+
+  /**
+   * Generates or retrieves a persistent session UUID for the browser session.
+   * Purpose: Provides a unique identifier for correlating requests within a session.
+   * Necessity: Enables server-side analytics and request tracking without exposing device fingerprint.
+   * UUID persists across page reloads but is cleared when tab/session closes.
+   */
+  function getSessionUuid() {
+    const sessionKey = SESSION_UUID_STORAGE_KEY;
+    let uuid = window.sessionStorage?.getItem(sessionKey);
+    if (!uuid) {
+      uuid = `${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+      if (window.sessionStorage) {
+        window.sessionStorage.setItem(sessionKey, uuid);
+      }
+    }
+    return uuid;
+  }
+
+  /**
+   * Computes a stable client fingerprint from browser/device attributes.
+   * Purpose: Creates a privacy-preserving identifier for requests from untrusted domains.
+   * Necessity: Balances analytics tracking with user privacy for non-trusted networks.
+   * Returns a 16-character hex string derived from UA, platform, language, CPU count, memory.
+   */
+  function computeClientFingerprint() {
+    const parts = [
+      navigator.userAgent,
+      navigator.platform,
+      navigator.language,
+      navigator.hardwareConcurrency || "unknown",
+      navigator.deviceMemory || "unknown",
+    ].join("|");
+
+    let hash = 0;
+    for (let i = 0; i < parts.length; i++) {
+      const char = parts.charCodeAt(i);
+      hash = (hash << 5) - hash + char;
+      hash = hash & hash;
+    }
+    return Math.abs(hash).toString(16).padStart(16, "0").substr(0, 16);
+  }
+
+  /**
+   * Determines if a domain is in the trusted domain list.
+   * Purpose: Implement domain-based trust policy for User-Agent header generation.
+   * Necessity: Distinguishes between trusted (localhost, peeringdb.com) and untrusted domains
+   * to decide whether to use full browser info or privacy-preserving fingerprint.
+   * Also normalizes IPv6 URIs with bracket notation ([::1]) for transparent matching.
+   */
+  function isDomainTrusted(domain) {
+    if (!domain) return false;
+    // Normalize: trim, lowercase, and strip IPv6 URI brackets (e.g., [::1] → ::1)
+    let domainText = String(domain).trim().toLowerCase();
+    if (domainText.startsWith("[") && domainText.endsWith("]")) {
+      domainText = domainText.slice(1, -1);
+    }
+    if (!domainText) return false;
+
+    for (const pattern of TRUSTED_DOMAINS_FOR_UA) {
+      const patternLower = pattern.toLowerCase();
+      if (patternLower === domainText) return true;
+
+      if (patternLower.startsWith("*.")) {
+        const baseDomain = patternLower.slice(2);
+        if (domainText === baseDomain || domainText.endsWith("." + baseDomain)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Constructs a User-Agent string based on domain trust level.
+   * Purpose: Provide contextual information to backend while respecting user privacy.
+   * Necessity: For trusted domains (development, peeringdb.com), includes browser/platform for debugging;
+   * for untrusted domains, uses fingerprint only to minimize data exposure.
+   * Includes session UUID in both cases for request correlation.
+   */
+  function buildTrustBasedUserAgent(domain) {
+    const isTrusted = isDomainTrusted(domain);
+    const sessionUuid = getSessionUuid();
+
+    if (isTrusted) {
+      const browserInfo = `${navigator.userAgent.split(" ").slice(-1)[0]} ${navigator.platform}`;
+      return `${DEFAULT_REQUEST_USER_AGENT} (${browserInfo} uuid/${sessionUuid})`;
+    }
+
+    const fingerprint = computeClientFingerprint();
+    return `${DEFAULT_REQUEST_USER_AGENT} (fingerprint/${fingerprint} uuid/${sessionUuid})`;
+  }
+
+  /**
+   * Retrieves explicit or auto-computed User-Agent for this session.
+   * Purpose: Provide flexible UA configuration with fallback to trust-based generation.
+   * Necessity: Allows manual override via localStorage while auto-computing from domain trust.
+   */
+  function getCustomRequestUserAgent() {
+    const configured = String(window.localStorage?.getItem(USER_AGENT_STORAGE_KEY) || "").trim();
+    if (configured) return configured;
+    return buildTrustBasedUserAgent(window.location.hostname);
+  }
+
+  /**
+   * Constructs HTTP headers for Tampermonkey requests with User-Agent.
+   * Purpose: Centralize header building for all script-initiated requests.
+   * Necessity: Ensures consistent User-Agent and other important headers across all API calls.
+   */
+  function buildTampermonkeyRequestHeaders(baseHeaders = {}) {
+    const headers = { ...baseHeaders };
+    const configured = String(window.localStorage?.getItem(USER_AGENT_STORAGE_KEY) || "").trim();
+
+    const userAgent =
+      configured ||
+      buildTrustBasedUserAgent(window.location.hostname);
+
+    if (userAgent) {
+      headers["User-Agent"] = userAgent;
+    }
+    return headers;
+  }
+
+  /**
+   * Parses the current URL to extract route context (entity type, ID, page kind).
+   * Purpose: Provide route info to modules for conditional execution.
+   * Necessity: Enables modules to match specific pages (e.g., /net/1234) and determine
+   * whether to run. Used by all modules' match() function.
+   */
   function getRouteContext() {
     const path = window.location.pathname;
     // Split and filter empty strings to handle leading/trailing slashes robustly
@@ -41,15 +218,30 @@
     };
   }
 
+  /**
+   * Convenience wrapper for querySelector.
+   * Purpose: Reduce boilerplate for DOM querying throughout the script.
+   * Necessity: Used extensively for finding form fields and toolbar elements.
+   */
   function qs(selector, root = document) {
     return root.querySelector(selector);
   }
 
+  /**
+   * Retrieves trimmed innerText from a selected element.
+   * Purpose: Safe extraction of display text for form fields and data fields.
+   * Necessity: Provides consistent empty-string fallback vs. throwing on missing elements.
+   */
   function getText(selector, root = document) {
     const el = qs(selector, root);
     return el ? el.innerText.trim() : "";
   }
 
+  /**
+   * Retrieves trimmed value from form input elements (input, select, textarea).
+   * Purpose: Unified value extraction that handles both .value property and data attributes.
+   * Necessity: Normalizes form field reading across different input types.
+   */
   function getInputValue(selector, root = document) {
     const el = qs(selector, root);
     if (!el) return "";
@@ -61,6 +253,11 @@
     return String(el.getAttribute("value") || "").trim();
   }
 
+  /**
+   * Copies text to clipboard with modern and fallback implementations.
+   * Purpose: Enable "Copy URL" and similar copy actions for user convenience.
+   * Necessity: Handles browsers with and without Clipboard API support.
+   */
   function copyToClipboard(text) {
     if (navigator.clipboard) {
       navigator.clipboard.writeText(text).catch((err) => {
@@ -83,10 +280,21 @@
     }
   }
 
+  /**
+   * Retrieves the container element for top-right toolbar buttons.
+   * Purpose: Centralize toolbar element selection with fallback selectors.
+   * Necessity: Top-right button area varies in PeeringDB pages; needs fallback chain.
+   */
   function getTopRightToolbarContainer(parentSelector = "div.right.button-bar > div:first-child") {
     return qs(parentSelector);
   }
 
+  /**
+   * Creates and appends an action button to the top-right toolbar.
+   * Purpose: Standardized way to add custom links (Admin Console, BGP tools, etc.) to FP pages.
+   * Necessity: Ensures consistent styling, idempotency (prevents duplicates), and event handling.
+   * Marks buttons with data-pdb-fp-action attribute for later reordering and identification.
+   */
   function createTopRightAction({
     actionId,
     label,
@@ -132,6 +340,12 @@
     return btn;
   }
 
+  /**
+   * Creates an overflow dropdown menu in the top-right toolbar.
+   * Purpose: Provide a compact menu for multiple related tools (RIPEstat, BGPView, CIDR Report, etc.).
+   * Necessity: Prevents toolbar overcrowding by grouping secondary network analysis tools.
+   * Manages menu open/close state and click-outside dismissal.
+   */
   function createTopRightOverflowMenu({
     actionId,
     label,
@@ -222,6 +436,11 @@
     return wrapper;
   }
 
+  /**
+   * Tests if a DOM element matches a given priority (CSS selector or function).
+   * Purpose: Support flexible matching in reorderChildrenByPriority (handles strings and predicates).
+   * Necessity: Enables both CSS-based matching and custom function-based matching in one API.
+   */
   function isPriorityMatch(child, priority) {
     if (!child || !priority) return false;
 
@@ -240,6 +459,12 @@
     }
   }
 
+  /**
+   * Reorders children of a container according to priority list.
+   * Purpose: Establish deterministic button order (Admin Console before BGP tools, etc.).
+   * Necessity: Ensures consistent UI layout across page variations and module load orders.
+   * Unmatched children stay in original order at the end.
+   */
   function reorderChildrenByPriority(container, priorities) {
     if (!container || !Array.isArray(priorities) || priorities.length === 0) return;
 
@@ -263,6 +488,11 @@
     ordered.forEach((child) => container.appendChild(child));
   }
 
+  /**
+   * Identifies if a child element is PeeringDB's native Edit toggle button.
+   * Purpose: Distinguish PeeringDB native structure from custom FP buttons.
+   * Necessity: Route native Edit button to separate row position per PeeringDB layout conventions.
+   */
   function isNativeEditToolbarButton(child) {
     if (!child) return false;
 
@@ -273,6 +503,11 @@
     return Boolean(qs('a[data-edit-action="toggle-edit"]', child));
   }
 
+  /**
+   * Applies flex layout to toolbar container for two-row button arrangement.
+   * Purpose: Enable column-based layout with right alignment and gap spacing.
+   * Necessity: Foundation for enforceTopRightButtonOrder two-row structure.
+   */
   function applyTopRightToolbarFlexLayout(parent) {
     if (!parent) return;
 
@@ -283,6 +518,11 @@
     parent.style.rowGap = "6px";
   }
 
+  /**
+   * Ensures a named row container exists in the toolbar.
+   * Purpose: Create or reuse row div with data-pdb-fp-row attribute for button grouping.
+   * Necessity: Routes buttons to two distinct visual rows (Edit/Admin/Copy-URL, then BGP tools).
+   */
   function ensureTopRightRowContainer(parent, rowName) {
     if (!parent || !rowName) return null;
 
@@ -302,6 +542,12 @@
     return row;
   }
 
+  /**
+   * Routes all toolbar buttons to two predetermined rows.
+   * Purpose: Implement the two-row layout convention (primary actions row 1, analysis tools row 2).
+   * Necessity: Creates visual hierarchy and improves mobile UX by grouping related actions.
+   * Hides empty rows to maintain clean toolbar appearance.
+   */
   function routeTopRightButtonsToTwoRows(parent) {
     if (!parent) return;
 
@@ -331,6 +577,11 @@
     row2.style.display = row2.children.length > 0 ? "flex" : "none";
   }
 
+  /**
+   * Groups custom toolbar items by vertical pixel position (visual rows).
+   * Purpose: Detect which buttons wrap to new lines due to narrow viewports.
+   * Necessity: Understand natural wrapping behavior for spacing adjustments.
+   */
   function groupCustomItemsByVisualRow(customItems, topTolerance = 3) {
     const rows = [];
 
@@ -355,6 +606,11 @@
     return rows;
   }
 
+  /**
+   * Removes individual button margins to rely on container gap for spacing.
+   * Purpose: Standardize spacing through flexbox gap instead of element margins.
+   * Necessity: Prevents double-spacing and inconsistent gaps from mixed margin/gap sources.
+   */
   function applyTopRightCustomSpacing(parent) {
     if (!parent) return;
 
@@ -370,6 +626,11 @@
     });
   }
 
+  /**
+   * Clears top margins on wrapped toolbar items.
+   * Purpose: Clean spacing when buttons wrap to multiple rows.
+   * Necessity: Prevents excessive vertical gaps when items wrap at narrow viewports.
+   */
   function applyTopRightWrappedRowOffset(parent) {
     if (!parent) return;
 
@@ -384,9 +645,24 @@
     });
   }
 
+  /**
+   * Enforces deterministic button order and layout in top-right toolbar.
+   * Purpose: Coordinate layout detection, reordering, and two-row routing for consistent UX.
+   * Necessity: Main orchestrator for toolbar DOM changes; detects when PeeringDB has already
+   * laid out buttons and skips processing to avoid interfering with native layout.
+   * Version 1.0.20 adds detection for pre-existing data-pdb-fp-row containers.
+   */
   function enforceTopRightButtonOrder() {
     const parent = getTopRightToolbarContainer();
     if (!parent) return;
+
+    // Skip re-layout if PeeringDB has already structured buttons into rows (data-pdb-fp-row).
+    // New PeeringDB versions handle button layout automatically; don't interfere.
+    const hasPreExistingRows = qs('div[data-pdb-fp-row]', parent);
+    if (hasPreExistingRows) {
+      // Buttons already placed by PeeringDB's native two-row layout.
+      return;
+    }
 
     applyTopRightToolbarFlexLayout(parent);
 
@@ -409,6 +685,11 @@
     applyTopRightWrappedRowOffset(parent);
   }
 
+  /**
+   * Convenience wrapper for createTopRightAction with minimal arguments.
+   * Purpose: Simplify button creation for module code.
+   * Necessity: Reduces boilerplate in module run functions.
+   */
   function addButton(label, onClick, parentSelector = "div.right.button-bar > div:first-child", actionId = "") {
     return createTopRightAction({
       actionId,
@@ -586,8 +867,13 @@
 
         if (!parent || !refNode) return;
 
+        // Guard: check if button already exists to prevent duplicates on re-init
+        const existing = qs('a[data-pdb-fp-copy-user-roles]', parent);
+        if (existing) return;
+
         const btn = document.createElement("a");
         btn.className = "btn btn-default";
+        btn.setAttribute("data-pdb-fp-copy-user-roles", "true");
         btn.style.textAlign = "center";
         btn.style.marginRight = "5px";
         btn.style.cursor = "pointer";
@@ -620,16 +906,90 @@
     },
   ];
 
-  const ctx = getRouteContext();
-  modules.forEach((module) => {
-    try {
-      if (module.match(ctx)) {
-        module.run(ctx);
-      }
-    } catch (e) {
-      console.warn(`[${MODULE_PREFIX}] Module ${module.id} failed`, e);
-    }
-  });
+  /**
+   * Executes all enabled modules that match the current route context.
+   * Purpose: Central dispatcher that activates modules for the current page.
+   * Necessity: Implements modular architecture; checks both enabled status and page match
+   * before running each module. Catches and logs errors to prevent cascade failures.
+   */
+  function dispatchModules(ctx) {
+    const disabledModules = getDisabledModules();
 
-  enforceTopRightButtonOrder();
+    modules.forEach((module) => {
+      try {
+        if (!isModuleEnabled(module.id, disabledModules)) return;
+        if (!module.match(ctx)) return;
+        if (typeof module.preconditions === "function" && !module.preconditions(ctx)) return;
+        module.run(ctx);
+      } catch (error) {
+        console.warn(`[${MODULE_PREFIX}] Module ${module.id} failed`, error);
+      }
+    });
+  }
+
+  /**
+   * Runs the complete initialization sequence for consolidated tools.
+   * Purpose: Parse route, dispatch modules, and enforce button order on current page.
+   * Necessity: Single entry point for all initialization logic; ensures modules run before layout.
+   * Sets isInitRunning flag to prevent duplicate initialization during mutations.
+   */
+  let isInitRunning = false;
+  function runConsolidatedInit() {
+    const ctx = getRouteContext();
+    isInitRunning = true;
+    try {
+      dispatchModules(ctx);
+      enforceTopRightButtonOrder();
+    } finally {
+      isInitRunning = false;
+    }
+  }
+
+  /**
+   * Schedules initialization to run on next animation frame, preventing duplicates.
+   * Purpose: Debounce repeated mutation events into a single initialization.
+   * Necessity: DOM mutations can fire many times per millisecond; this batches them into
+   * one operation to avoid redundant module calls and button reordering.
+   */
+  let initScheduled = false;
+  function scheduleConsolidatedInit() {
+    // Prevent triggering while modules are actively running (to avoid duplicate DOM insertions)
+    if (initScheduled || isInitRunning) return;
+    initScheduled = true;
+
+    requestAnimationFrame(() => {
+      initScheduled = false;
+      runConsolidatedInit();
+    });
+  }
+
+  /**
+   * Bootstrap the consolidated init system and attach event listeners.
+   * Purpose: Initialize the script on page load or immediately if DOM is ready.
+   * Necessity: Entry point that hooks into DOMContentLoaded, popstate (SPA navigation),
+   * and DOM mutations to detect when init should run. Sets up MutationObserver for AJAX/PJAX pages.
+   */
+  function bootstrapConsolidatedInit() {
+    scheduleConsolidatedInit();
+
+    window.addEventListener("popstate", scheduleConsolidatedInit);
+    window.addEventListener("hashchange", scheduleConsolidatedInit);
+
+    if (document.body) {
+      const observer = new MutationObserver(() => {
+        // Only allow re-init triggered by MutationObserver if not already running
+        if (!isInitRunning) {
+          scheduleConsolidatedInit();
+        }
+      });
+
+      observer.observe(document.body, { childList: true, subtree: true });
+    }
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", bootstrapConsolidatedInit, { once: true });
+  } else {
+    bootstrapConsolidatedInit();
+  }
 })();


### PR DESCRIPTION
This PR refines CP rendered-field copy behavior to reduce noise and only expose copy actions for meaningful values.

Changes:
- adds rendered field copy icons and extraction logic for visible values
- adds permanent deny-list exclusions for IX-F and metadata rows
- adds exact-match conditional exclusion for empty technical/policy/sales phone and email fields
- removes helper-only text from fallback copy extraction
- syncs userscript/meta versions to `1.0.49`

Testing:
- reviewed selector and matching logic in script diff
- validated exact-match conditional label checks in code paths
- runtime browser validation to be completed in CP UI

Backwards Compatibility:
- scoped to copy-button visibility and copied value resolution only
- existing CP toolbar actions remain unchanged

Closes #287