### PR TITLE
release(user.js): ship CP v2 + FP sync updates

### DIFF
--- a/user.js/peeringdb-cp-consolidated-tools.meta.js
+++ b/user.js/peeringdb-cp-consolidated-tools.meta.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         PeeringDB CP - Consolidated Tools
 // @namespace    https://www.peeringdb.com/cp/
-// @version      1.0.50.20260323
+// @version      2.0.0.20260323
 // @description  Consolidated CP userscript with strict route-isolated modules for facility/network/user/entity workflows
 // @author       <chriztoffer@peeringdb.com>
 // @match        https://www.peeringdb.com/cp/peeringdb_server/*/*/change/*

--- a/user.js/peeringdb-cp-consolidated-tools.meta.js
+++ b/user.js/peeringdb-cp-consolidated-tools.meta.js
@@ -7,6 +7,7 @@
 // @match        https://www.peeringdb.com/cp/peeringdb_server/*/*/change/*
 // @icon         https://icons.duckduckgo.com/ip2/peeringdb.com.ico
 // @grant        GM_xmlhttpRequest
+// @grant        GM_notification
 // @run-at       document-end
 // @connect      data.iana.org
 // @connect      rdap.arin.net

--- a/user.js/peeringdb-cp-consolidated-tools.meta.js
+++ b/user.js/peeringdb-cp-consolidated-tools.meta.js
@@ -8,6 +8,7 @@
 // @icon         https://icons.duckduckgo.com/ip2/peeringdb.com.ico
 // @grant        GM_xmlhttpRequest
 // @grant        GM_notification
+// @grant        GM_registerMenuCommand
 // @run-at       document-end
 // @connect      data.iana.org
 // @connect      rdap.arin.net

--- a/user.js/peeringdb-cp-consolidated-tools.user.js
+++ b/user.js/peeringdb-cp-consolidated-tools.user.js
@@ -1039,6 +1039,35 @@
     return `${fallback || "Entity"} Website`;
   }
 
+  /**
+   * Returns human-friendly frontend label for a CP entity.
+   * Purpose: Make the main frontend action explicit about the destination entity type.
+   * Necessity: Replaces generic "Frontend" text with entity-specific naming.
+   */
+  function getEntityFrontendLabel(entity) {
+    const frontendLabelByEntity = {
+      internetexchange: "IX (front-end)",
+      network: "Network (front-end)",
+      facility: "Facility (front-end)",
+      organization: "Org (front-end)",
+      carrier: "Carrier (front-end)",
+      campus: "Campus (front-end)",
+    };
+
+    if (frontendLabelByEntity[entity]) {
+      return frontendLabelByEntity[entity];
+    }
+
+    const fallback = String(entity || "")
+      .trim()
+      .replace(/[_-]+/g, " ")
+      .replace(/\s+/g, " ")
+      .toLowerCase()
+      .replace(/\b\w/g, (char) => char.toUpperCase());
+
+    return `${fallback || "Entity"} (front-end)`;
+  }
+
   function getOrganizationIdForNameUpdate(ctx) {
     if (!ctx?.isEntityChangePage) return "";
     if (ctx.entity === "organization") return String(ctx.entityId || "").trim();
@@ -2587,7 +2616,7 @@
 
         addToolbarAction({
           id: `${MODULE_PREFIX}Frontend`,
-          label: "Frontend",
+          label: getEntityFrontendLabel(ctx.entity),
           href: `/${goto}/${ctx.entityId}`,
           target: "_new",
         });

--- a/user.js/peeringdb-cp-consolidated-tools.user.js
+++ b/user.js/peeringdb-cp-consolidated-tools.user.js
@@ -77,6 +77,69 @@
     "sales email",
   ]);
   const orgNameMemoryCache = new Map();
+  const openDropdownActionItems = new Set();
+  let dropdownGlobalCloseListenerBound = false;
+
+  /**
+   * Closes a single dropdown action item and resets its toggle accessibility state.
+   * Purpose: Provide centralized close behavior for toolbar and secondary-row dropdowns.
+   * Necessity: Shared close logic prevents duplicated listener code per dropdown instance.
+   */
+  function closeDropdownActionItem(listItem) {
+    if (!listItem) return;
+
+    const toggle = qs("a[id]", listItem);
+    const menu = qs(":scope > div", listItem);
+    if (menu) {
+      menu.style.display = "none";
+    }
+
+    if (toggle) {
+      toggle.setAttribute("aria-expanded", "false");
+    }
+
+    listItem.removeAttribute("data-open");
+    listItem.style.zIndex = "";
+    openDropdownActionItems.delete(listItem);
+  }
+
+  /**
+   * Closes all open dropdowns except an optional exempt item.
+   * Purpose: Enforce single-open-dropdown behavior across custom CP action menus.
+   * Necessity: Simplifies global click/escape handling and keeps UI predictable.
+   */
+  function closeAllDropdownActionItems(exemptItem = null) {
+    Array.from(openDropdownActionItems).forEach((listItem) => {
+      if (exemptItem && listItem === exemptItem) return;
+      closeDropdownActionItem(listItem);
+    });
+  }
+
+  /**
+   * Registers one global listener pair for dropdown close behavior.
+   * Purpose: Replace per-dropdown document listeners with one shared close handler.
+   * Necessity: Reduces global event listener count and improves maintainability.
+   */
+  function ensureDropdownGlobalCloseListener() {
+    if (dropdownGlobalCloseListenerBound) return;
+    dropdownGlobalCloseListenerBound = true;
+
+    document.addEventListener("click", (event) => {
+      const target = event?.target;
+      const activeItems = Array.from(openDropdownActionItems);
+      if (!activeItems.length) return;
+
+      const clickedInsideAnyOpenItem = activeItems.some((listItem) => listItem.contains(target));
+      if (!clickedInsideAnyOpenItem) {
+        closeAllDropdownActionItems();
+      }
+    });
+
+    document.addEventListener("keydown", (event) => {
+      if (event.key !== "Escape") return;
+      closeAllDropdownActionItems();
+    });
+  }
 
   /**
    * Normalizes organization ID into a stable cache key suffix.
@@ -632,6 +695,7 @@
 
   function createDropdownActionListItem({ id, label, items }) {
     if (!id || !Array.isArray(items) || items.length === 0) return null;
+    ensureDropdownGlobalCloseListener();
 
     const li = document.createElement("li");
     li.style.position = "relative";
@@ -668,44 +732,35 @@
       link.style.display = "block";
       link.style.whiteSpace = "nowrap";
       link.style.padding = "2px 4px";
+      link.addEventListener("click", () => {
+        closeDropdownActionItem(li);
+      });
       menu.appendChild(link);
     });
 
     const closeMenu = () => {
-      menu.style.display = "none";
-      toggle.setAttribute("aria-expanded", "false");
-      li.removeAttribute("data-open");
-      li.style.zIndex = "";
+      closeDropdownActionItem(li);
     };
 
     toggle.addEventListener("click", (event) => {
+      event.preventDefault();
+      event.stopPropagation();
       const isOpen = li.getAttribute("data-open") === "1";
       if (isOpen) {
         closeMenu();
         return;
       }
 
+      closeAllDropdownActionItems(li);
       menu.style.display = "flex";
       toggle.setAttribute("aria-expanded", "true");
       li.setAttribute("data-open", "1");
       li.style.zIndex = "1001";
+      openDropdownActionItems.add(li);
     });
 
     menu.addEventListener("click", (event) => {
       event.stopPropagation();
-    });
-
-    toggle.addEventListener("keydown", (event) => {
-      if (event.key === "Escape") {
-        closeMenu();
-      }
-    });
-
-    document.addEventListener("click", (event) => {
-      if (li.getAttribute("data-open") !== "1") return;
-      if (!li.contains(event.target)) {
-        closeMenu();
-      }
     });
 
     li.appendChild(toggle);

--- a/user.js/peeringdb-cp-consolidated-tools.user.js
+++ b/user.js/peeringdb-cp-consolidated-tools.user.js
@@ -4,7 +4,7 @@
 // @version      1.0.50.20260323
 // @description  Consolidated CP userscript with strict route-isolated modules for facility/network/user/entity workflows
 // @author       <chriztoffer@peeringdb.com>
-// @match        https://www.peeringdb.com/cp/peeringdb_server/*/*/change/*
+// @match        https://www.peeringdb.com/cp/peeringdb_server/*
 // @icon         https://icons.duckduckgo.com/ip2/peeringdb.com.ico
 // @grant        GM_xmlhttpRequest
 // @grant        GM_notification
@@ -789,7 +789,7 @@
    * re-parsing the URL each time — centralizing parsing prevents divergent path logic.
    * @returns {{ host: string, path: string[], pathName: string, isCp: boolean,
    *             entity: string, entityId: string, pageKind: string,
-   *             isEntityChangePage: boolean }}
+   *             isEntityChangePage: boolean, isEntityListPage: boolean }}
    */
   function getRouteContext() {
     const path = window.location.pathname.replace(/(^\/|\/$)/g, "").split("/");
@@ -803,6 +803,8 @@
       pageKind: path[4] || "",
       isEntityChangePage:
         path[0] === "cp" && path[1] === "peeringdb_server" && path[4] === "change",
+      isEntityListPage:
+        path[0] === "cp" && path[1] === "peeringdb_server" && Boolean(path[2]) && !path[3],
     };
   }
 
@@ -2083,6 +2085,47 @@
   }
 
   /**
+   * Collects all currently rendered CP object change links from the active overview page.
+   * Purpose: Support one-click copying of every visible change-page URL from a filtered list.
+   * Necessity: Admin overview pages often expose many object rows and copying them manually
+   * is tedious; harvesting current row links preserves the user's active filter/pagination view.
+   * @returns {string[]} Ordered, de-duplicated absolute change URLs currently present in the content area.
+   */
+  function getCurrentOverviewChangeLinks() {
+    const anchors = qsa('#grp-content-container a[href*="/cp/peeringdb_server/"][href*="/change/"]');
+    const seen = new Set();
+
+    return anchors
+      .map((anchor) => {
+        const rawHref = String(anchor.getAttribute("href") || "").trim();
+        if (!rawHref) return "";
+
+        let absoluteUrl = "";
+        try {
+          absoluteUrl = new URL(rawHref, window.location.origin).toString();
+        } catch (_error) {
+          return "";
+        }
+
+        let parsed;
+        try {
+          parsed = new URL(absoluteUrl);
+        } catch (_error) {
+          return "";
+        }
+
+        if (!/^\/cp\/peeringdb_server\/[^/]+\/[^/]+\/change\/?$/i.test(parsed.pathname)) {
+          return "";
+        }
+
+        if (seen.has(absoluteUrl)) return "";
+        seen.add(absoluteUrl);
+        return absoluteUrl;
+      })
+      .filter(Boolean);
+  }
+
+  /**
    * Shows a non-blocking userscript notification when supported.
    * Purpose: Surface completion/failure status for long-running CP actions.
    * Necessity: Async updates may complete after several network calls and benefit from toasts.
@@ -2861,6 +2904,45 @@
   // (ctx predicate), and run (ctx handler that may return a dispose function).
   // ---------------------------------------------------------------------------
   const modules = [
+    {
+      id: "copy-overview-change-links",
+      match: (ctx) => ctx.isEntityListPage,
+      preconditions: () => Boolean(getToolbarList()),
+      run: (ctx) => {
+        addToolbarAction({
+          id: `${MODULE_PREFIX}CopyOverviewChangeLinks`,
+          label: "Copy change links",
+          insertLeft: true,
+          onClick: async (event) => {
+            const links = getCurrentOverviewChangeLinks();
+            if (links.length === 0) {
+              pulseToolbarButton(event?.target, "No links");
+              notifyUser({
+                title: "PeeringDB CP",
+                text: `No change links found on current ${ctx.entity || "overview"} page.`,
+              });
+              return;
+            }
+
+            const copied = await copyToClipboard(links.join("\n"));
+            if (copied) {
+              pulseToolbarButton(event?.target, `Copied ${links.length}`);
+              notifyUser({
+                title: "PeeringDB CP",
+                text: `Copied ${links.length} change link${links.length === 1 ? "" : "s"}.`,
+              });
+              return;
+            }
+
+            pulseToolbarButton(event?.target, "Copy failed");
+            notifyUser({
+              title: "PeeringDB CP",
+              text: "Failed to copy overview change links.",
+            });
+          },
+        });
+      },
+    },
     {
       id: "copy-frontend-urls",
       match: (ctx) => ctx.isEntityChangePage,
@@ -3723,11 +3805,13 @@
   function runConsolidatedInit() {
     const ctx = getRouteContext();
 
-    if (!ctx.isCp || !ctx.isEntityChangePage) {
+    if (!ctx.isCp || (!ctx.isEntityChangePage && !ctx.isEntityListPage)) {
       return;
     }
 
-    runSelfCheck(ctx);
+    if (ctx.isEntityChangePage) {
+      runSelfCheck(ctx);
+    }
     dbg("init", `v${SCRIPT_VERSION}`, { entity: ctx.entity, entityId: ctx.entityId });
     cleanupLegacyPrimaryActionRow();
     dispatchModules(ctx);

--- a/user.js/peeringdb-cp-consolidated-tools.user.js
+++ b/user.js/peeringdb-cp-consolidated-tools.user.js
@@ -232,6 +232,7 @@
     const { state } = resolveEntityVisualState(ctx);
 
     const dummyMarkerClass = "pdb-dummy-org-child-marker";
+    const pendingBadgeClass = "pdb-pending-badge";
     const deletedBadgeClass = "pdb-deleted-badge";
 
     const existingDummyMarker = qs(`.${dummyMarkerClass}`, title);
@@ -246,6 +247,20 @@
       }
     } else if (existingDummyMarker) {
       existingDummyMarker.remove();
+    }
+
+    const existingPendingBadge = qs(`.${pendingBadgeClass}`, title);
+    if (state === "pending") {
+      if (!existingPendingBadge) {
+        const badge = document.createElement("span");
+        badge.className = pendingBadgeClass;
+        badge.style.cssText =
+          "margin-left:10px;color:#e65c00;font-weight:bold;font-size:0.8em;letter-spacing:0.05em;vertical-align:middle;";
+        badge.textContent = "PENDING";
+        title.appendChild(badge);
+      }
+    } else if (existingPendingBadge) {
+      existingPendingBadge.remove();
     }
 
     const existingDeletedBadge = qs(`.${deletedBadgeClass}`, title);

--- a/user.js/peeringdb-cp-consolidated-tools.user.js
+++ b/user.js/peeringdb-cp-consolidated-tools.user.js
@@ -142,6 +142,7 @@
    * Items not matched by any entry are left in their original relative order.
    */
   const TOOLBAR_PRIMARY_ORDER = [
+    `li[data-pdb-cp-action="${MODULE_PREFIX}ApiJson"]`,
     `li[data-pdb-cp-action="${MODULE_PREFIX}ResetNetworkInformation"]`,
     `li[data-pdb-cp-action="${MODULE_PREFIX}Frontend"]`,
     `li[data-pdb-cp-action="${MODULE_PREFIX}OrganizationFrontend"]`,
@@ -979,6 +980,19 @@
     const entityId = String(ctx?.entityId || "").trim();
     if (!resource || !entityId) return "";
     return `https://www.peeringdb.com/api/${resource}/${entityId}`;
+  }
+
+  /**
+   * Determines whether the API JSON action should be visible for current context.
+   * Purpose: Avoid showing the button when action policy does not allow opening.
+   * Necessity: Prevent no-op UI affordances for non-OK entities.
+   */
+  function shouldShowApiJsonAction(ctx) {
+    const apiJsonUrl = getEntityApiJsonUrl(ctx);
+    if (!apiJsonUrl) return false;
+
+    const status = String(getSelectedStatus() || "").trim().toLowerCase();
+    return status === "ok";
   }
 
   function getEntityCopyLabel(entity) {
@@ -2262,12 +2276,13 @@
         const entityUrl = entityPath ? `https://www.peeringdb.com${entityPath}` : "";
 
         const apiJsonUrl = getEntityApiJsonUrl(ctx);
-        if (apiJsonUrl) {
+        if (shouldShowApiJsonAction(ctx) && apiJsonUrl) {
           addToolbarAction({
             id: `${MODULE_PREFIX}ApiJson`,
             label: "API JSON",
             href: apiJsonUrl,
             target: "_new",
+            insertLeft: true,
             onClick: (event) => {
               const status = String(getSelectedStatus() || "").trim().toLowerCase();
               if (status !== "ok") {

--- a/user.js/peeringdb-cp-consolidated-tools.user.js
+++ b/user.js/peeringdb-cp-consolidated-tools.user.js
@@ -2175,12 +2175,18 @@
     });
 
     eachInForm('select[name*="info"]', (item) => {
+      if (item.multiple) {
+        Array.from(item.options).forEach((opt) => { opt.selected = false; });
+      }
       const firstOption = qs("option:first-child", item);
       if (firstOption) {
         firstOption.selected = true;
       }
     });
     eachInForm('select[name*="policy"]', (item) => {
+      if (item.multiple) {
+        Array.from(item.options).forEach((opt) => { opt.selected = false; });
+      }
       const firstOption = qs("option:first-child", item);
       if (firstOption) {
         firstOption.selected = true;

--- a/user.js/peeringdb-cp-consolidated-tools.user.js
+++ b/user.js/peeringdb-cp-consolidated-tools.user.js
@@ -142,6 +142,8 @@
    * Items not matched by any entry are left in their original relative order.
    */
   const TOOLBAR_PRIMARY_ORDER = [
+    `li[data-pdb-cp-action="${MODULE_PREFIX}ObjTypeWebsite"]`,
+    `li[data-pdb-cp-action="${MODULE_PREFIX}ObjOrgWebsite"]`,
     `li[data-pdb-cp-action="${MODULE_PREFIX}ApiJson"]`,
     `li[data-pdb-cp-action="${MODULE_PREFIX}ResetNetworkInformation"]`,
     `li[data-pdb-cp-action="${MODULE_PREFIX}Frontend"]`,
@@ -1925,6 +1927,42 @@
   }
 
   /**
+   * Reads a readonly link href from a form row by its visible label text.
+   * Purpose: Reuse row-level links (e.g. Org website) as header actions.
+   * Necessity: Some URLs are rendered as readonly anchors rather than inputs.
+   */
+  function getReadonlyFieldLinkHrefByLabel(labelText) {
+    const normalizedLabel = String(labelText || "").trim().toLowerCase();
+    if (!normalizedLabel) return "";
+
+    const row = qsa(".form-row").find((item) => {
+      const label = normalizeRenderedCopyText(
+        (qs(".c-1 label", item) || qs(".c-1", item))?.textContent || "",
+      ).toLowerCase();
+      return label === normalizedLabel;
+    });
+
+    return normalizeRenderedCopyText(qs(".c-2 a[href^='http://'], .c-2 a[href^='https://']", row)?.getAttribute("href") || "");
+  }
+
+  /**
+   * Builds a stable link identity derived from Grainy namespace when available.
+   * Purpose: Use deterministic per-object identity in window targets and action semantics.
+   * Necessity: Avoid fragile IDs while preserving object-level context in opened links.
+   */
+  function getGrainyDerivedLinkIdentity(ctx) {
+    const grainyNamespace = getReadonlyFieldValueByLabel("Grainy namespace");
+    const fallbackIdentity = `${String(ctx?.entity || "").trim()}_${String(ctx?.entityId || "").trim()}`;
+    const base = String(grainyNamespace || fallbackIdentity || "").trim();
+
+    return base
+      .replace(/^peeringdb\./i, "")
+      .replace(/[^a-z0-9]+/gi, "_")
+      .replace(/^_+|_+$/g, "")
+      .toLowerCase();
+  }
+
+  /**
    * Marks inline form rows (POCs, netfacs, netixlans) for deletion if status = 'deleted'.
    * Purpose: Clean up stale inline items when network status is deleted.
    * Necessity: Automatic cleanup prevents orphaned POCs/facilities when network is marked deleted.
@@ -2388,6 +2426,38 @@
         if (!website) return;
 
         website.target = `peeringdb_${ctx.entity}_${ctx.entityId}`;
+      },
+    },
+    {
+      id: "entity-website-header-links",
+      match: (ctx) => ctx.isEntityChangePage,
+      preconditions: () => Boolean(getToolbarList()),
+      run: (ctx) => {
+        const grainyIdentity = getGrainyDerivedLinkIdentity(ctx);
+
+        const objTypeWebsiteUrl = String(
+          getInputValue("#id_website") || getReadonlyFieldLinkHrefByLabel("Website") || "",
+        ).trim();
+        if (/^https?:\/\//i.test(objTypeWebsiteUrl)) {
+          addToolbarAction({
+            id: `${MODULE_PREFIX}ObjTypeWebsite`,
+            label: "ObjType Website",
+            href: objTypeWebsiteUrl,
+            target: `pdb_${grainyIdentity}_objtype_website`,
+            insertLeft: true,
+          });
+        }
+
+        const objOrgWebsiteUrl = String(getReadonlyFieldLinkHrefByLabel("Org website") || "").trim();
+        if (/^https?:\/\//i.test(objOrgWebsiteUrl)) {
+          addToolbarAction({
+            id: `${MODULE_PREFIX}ObjOrgWebsite`,
+            label: "ObjOrg Website",
+            href: objOrgWebsiteUrl,
+            target: `pdb_${grainyIdentity}_objorg_website`,
+            insertLeft: true,
+          });
+        }
       },
     },
     {

--- a/user.js/peeringdb-cp-consolidated-tools.user.js
+++ b/user.js/peeringdb-cp-consolidated-tools.user.js
@@ -3248,6 +3248,64 @@
       },
     },
     {
+      id: "request-ixf-import",
+      match: (ctx) => ctx.isEntityChangePage && ctx.entity === "internetexchange",
+      preconditions: () => Boolean(getToolbarList()),
+      run: (ctx) => {
+        addToolbarAction({
+          id: `${MODULE_PREFIX}RequestIxfImport`,
+          label: "Request IXF Import",
+          insertLeft: true,
+          onClick: async (event) => {
+            const actionLockKey = `${MODULE_PREFIX}.requestIxfImport.${ctx.entityId}`;
+            if (!tryBeginActionLock(actionLockKey)) {
+              notifyUser({
+                title: "PeeringDB CP",
+                text: "Request IXF Import is already running.",
+              });
+              return;
+            }
+
+            try {
+              const button = event.target;
+              button.textContent = "Requesting...";
+              button.style.opacity = "0.7";
+              button.style.pointerEvents = "none";
+
+              const endpoint = `${PEERINGDB_API_BASE_URL}/ix/${ctx.entityId}/request_ixf_import`;
+              const result = await pdbPost(endpoint, "POST", {});
+
+              if (result.status >= 200 && result.status < 300) {
+                notifyUser({
+                  title: "PeeringDB CP",
+                  text: "IXF import request submitted successfully.",
+                });
+              } else {
+                notifyUser({
+                  title: "PeeringDB CP",
+                  text: `IXF import request failed (HTTP ${result.status}).`,
+                });
+              }
+            } catch (error) {
+              console.error(`[${MODULE_PREFIX}] Request IXF Import failed`, error);
+              notifyUser({
+                title: "PeeringDB CP",
+                text: "Request IXF Import failed. See console for details.",
+              });
+            } finally {
+              const button = event?.target;
+              if (button) {
+                button.textContent = "Request IXF Import";
+                button.style.opacity = "";
+                button.style.pointerEvents = "";
+              }
+              endActionLock(actionLockKey);
+            }
+          },
+        });
+      },
+    },
+    {
       id: "ixf-import-status-badge",
       match: (ctx) => ctx.isEntityChangePage && ctx.entity === "internetexchange",
       preconditions: () => Boolean(qs("#grp-content-title")),

--- a/user.js/peeringdb-cp-consolidated-tools.user.js
+++ b/user.js/peeringdb-cp-consolidated-tools.user.js
@@ -104,6 +104,19 @@
   const ENTITY_TYPES_OWN_NAME = new Set(["organization", "facility", "internetexchange"]);
 
   /**
+   * Unified entity slug mapping for frontend URLs and API resource paths.
+   * Both getFrontendSlugByEntity and getEntityApiResourceByEntity delegate to this map.
+   */
+  const ENTITY_SLUG_MAP = {
+    facility: "fac",
+    network: "net",
+    organization: "org",
+    carrier: "carrier",
+    internetexchange: "ix",
+    campus: "campus",
+  };
+
+  /**
    * Django admin inline-set DOM ID prefixes for network child relations.
    * Used by markDeletedNetworkInlinesForDeletion to iterate all inline sets.
    */
@@ -923,16 +936,7 @@
   }
 
   function getFrontendSlugByEntity(entity) {
-    const slugByEntity = {
-      facility: "fac",
-      network: "net",
-      organization: "org",
-      carrier: "carrier",
-      internetexchange: "ix",
-      campus: "campus",
-    };
-
-    return slugByEntity[entity] || "";
+    return ENTITY_SLUG_MAP[entity] || "";
   }
 
   function getEntityFrontendPath(ctx) {
@@ -947,16 +951,7 @@
    * Necessity: CP workflows often require quick access to canonical API payloads.
    */
   function getEntityApiResourceByEntity(entity) {
-    const apiResourceByEntity = {
-      facility: "fac",
-      network: "net",
-      organization: "org",
-      carrier: "carrier",
-      internetexchange: "ix",
-      campus: "campus",
-    };
-
-    return apiResourceByEntity[entity] || "";
+    return ENTITY_SLUG_MAP[entity] || "";
   }
 
   /**

--- a/user.js/peeringdb-cp-consolidated-tools.user.js
+++ b/user.js/peeringdb-cp-consolidated-tools.user.js
@@ -79,6 +79,7 @@
     "sales email",
   ]);
   const orgNameMemoryCache = new Map();
+  const activeActionLocks = new Set();
   const openDropdownActionItems = new Set();
   let dropdownGlobalCloseListenerBound = false;
 
@@ -141,6 +142,31 @@
       if (event.key !== "Escape") return;
       closeAllDropdownActionItems();
     });
+  }
+
+  /**
+   * Attempts to acquire a named action lock.
+   * Purpose: Prevent duplicate execution for long-running script-driven actions.
+   * Necessity: Double clicks or repeated menu triggers can race and produce duplicate saves.
+   */
+  function tryBeginActionLock(lockKey) {
+    const normalizedKey = String(lockKey || "").trim();
+    if (!normalizedKey) return false;
+    if (activeActionLocks.has(normalizedKey)) return false;
+
+    activeActionLocks.add(normalizedKey);
+    return true;
+  }
+
+  /**
+   * Releases a previously acquired action lock.
+   * Purpose: Re-enable action execution after async work completes.
+   * Necessity: Locks must always be released to avoid permanent action blocking.
+   */
+  function endActionLock(lockKey) {
+    const normalizedKey = String(lockKey || "").trim();
+    if (!normalizedKey) return;
+    activeActionLocks.delete(normalizedKey);
   }
 
   /**
@@ -1956,48 +1982,61 @@
           id: `${MODULE_PREFIX}UpdateEntityName`,
           label: "Update Name",
           onClick: async (event) => {
-            const appendName = getNameSuffixForDeletedEntity(ctx.entityId);
-            let baseName;
-            if (["organization", "facility", "internetexchange"].includes(ctx.entity)) {
-              const rawName = getInputValue("#id_name");
-              const existingSuffix = ` #${ctx.entityId}`;
-              baseName = rawName.endsWith(existingSuffix)
-                ? rawName.slice(0, -existingSuffix.length)
-                : rawName;
-            } else {
-              const anchor = event?.target;
-              if (anchor) {
-                anchor.textContent = "Updating...";
-                anchor.style.opacity = "0.7";
-                anchor.style.pointerEvents = "none";
-              }
-              const orgId = getOrganizationIdForNameUpdate(ctx);
-              baseName = await getOrganizationName(orgId);
-              if (anchor) {
-                anchor.textContent = "Update Name";
-                anchor.style.opacity = "";
-                anchor.style.pointerEvents = "";
-              }
-              if (!baseName) {
-                notifyUser({
-                  title: "PeeringDB CP",
-                  text: "Update Name: failed to resolve organization name.",
-                });
-                return;
-              }
+            const actionLockKey = `${MODULE_PREFIX}.updateEntityName.${ctx.entity}.${ctx.entityId}`;
+            if (!tryBeginActionLock(actionLockKey)) {
+              notifyUser({
+                title: "PeeringDB CP",
+                text: "Update Name is already running.",
+              });
+              return;
             }
 
-            const nextName = `${baseName}${appendName}`;
-            const currentName = getInputValue("#id_name");
-            if (nextName === currentName) return;
+            try {
+              const appendName = getNameSuffixForDeletedEntity(ctx.entityId);
+              let baseName;
+              if (["organization", "facility", "internetexchange"].includes(ctx.entity)) {
+                const rawName = getInputValue("#id_name");
+                const existingSuffix = ` #${ctx.entityId}`;
+                baseName = rawName.endsWith(existingSuffix)
+                  ? rawName.slice(0, -existingSuffix.length)
+                  : rawName;
+              } else {
+                const anchor = event?.target;
+                if (anchor) {
+                  anchor.textContent = "Updating...";
+                  anchor.style.opacity = "0.7";
+                  anchor.style.pointerEvents = "none";
+                }
+                const orgId = getOrganizationIdForNameUpdate(ctx);
+                baseName = await getOrganizationName(orgId);
+                if (anchor) {
+                  anchor.textContent = "Update Name";
+                  anchor.style.opacity = "";
+                  anchor.style.pointerEvents = "";
+                }
+                if (!baseName) {
+                  notifyUser({
+                    title: "PeeringDB CP",
+                    text: "Update Name: failed to resolve organization name.",
+                  });
+                  return;
+                }
+              }
 
-            markDeletedNetworkInlinesForDeletion();
-            setInputValue("#id_name", nextName);
-            clickSaveAndContinue();
-            notifyUser({
-              title: "PeeringDB CP",
-              text: `Update Name: saved '${nextName}'.`,
-            });
+              const nextName = `${baseName}${appendName}`;
+              const currentName = getInputValue("#id_name");
+              if (nextName === currentName) return;
+
+              markDeletedNetworkInlinesForDeletion();
+              setInputValue("#id_name", nextName);
+              clickSaveAndContinue();
+              notifyUser({
+                title: "PeeringDB CP",
+                text: `Update Name: saved '${nextName}'.`,
+              });
+            } finally {
+              endActionLock(actionLockKey);
+            }
           },
         });
       },
@@ -2012,20 +2051,28 @@
           label: "Reset Information",
           insertLeft: true,
           onClick: async (event) => {
-            const asn = getInputValue("#id_asn");
-            const networkName = getInputValue("#id_name");
-
-            if (!confirmDangerousReset(asn, networkName, ctx.entityId)) {
+            const actionLockKey = `${MODULE_PREFIX}.resetNetworkInformation.${ctx.entityId}`;
+            if (!tryBeginActionLock(actionLockKey)) {
+              notifyUser({
+                title: "PeeringDB CP",
+                text: "Reset Information is already running.",
+              });
               return;
             }
 
-            const button = event.target;
-            const originalLabel = button.textContent;
-            button.textContent = "Processing...";
-            button.style.opacity = "0.7";
-            button.style.pointerEvents = "none";
-
             try {
+              const asn = getInputValue("#id_asn");
+              const networkName = getInputValue("#id_name");
+
+              if (!confirmDangerousReset(asn, networkName, ctx.entityId)) {
+                return;
+              }
+
+              const button = event.target;
+              button.textContent = "Processing...";
+              button.style.opacity = "0.7";
+              button.style.pointerEvents = "none";
+
               const orgId = getInputValue("#id_org");
               const appendName = getNameSuffixForDeletedEntity(ctx.entityId);
               let usedRdapFallback = false;
@@ -2077,9 +2124,20 @@
                 title: "PeeringDB CP",
                 text: "Reset Information failed. See console for details.",
               });
-              button.textContent = originalLabel;
-              button.style.opacity = "1";
-              button.style.pointerEvents = "auto";
+              const button = event?.target;
+              if (button) {
+                button.textContent = "Reset Information";
+                button.style.opacity = "1";
+                button.style.pointerEvents = "auto";
+              }
+            } finally {
+              const button = event?.target;
+              if (button) {
+                button.textContent = "Reset Information";
+                button.style.opacity = "";
+                button.style.pointerEvents = "";
+              }
+              endActionLock(actionLockKey);
             }
           },
         });

--- a/user.js/peeringdb-cp-consolidated-tools.user.js
+++ b/user.js/peeringdb-cp-consolidated-tools.user.js
@@ -1358,6 +1358,65 @@
   }
 
   /**
+   * Unified JSON fetch helper for all script-initiated HTTP requests.
+   * Purpose: Single network abstraction with timeout, retry, and error normalisation
+   * for both same-origin (PeeringDB API via fetch) and cross-origin (RDAP via
+   * GM_xmlhttpRequest) call sites.
+   * Necessity: Prevents N ad-hoc GM_xmlhttpRequest patterns from diverging on
+   * timeout handling or header construction.
+   * @param {string} url - Absolute URL to fetch.
+   * @param {{ headers?: object, timeout?: number, retries?: number }} [options]
+   * @returns {Promise<object|null>} Parsed JSON or null on any failure.
+   */
+  async function pdbFetch(url, { headers = {}, timeout = 12000, retries = 1 } = {}) {
+    const fullHeaders = buildTampermonkeyRequestHeaders(headers);
+    let hostname = "";
+    try { hostname = new URL(url).hostname; } catch (_err) { /* keep empty hostname */ }
+    const isSameOrigin = hostname === window.location.hostname;
+
+    if (isSameOrigin) {
+      for (let attempt = 0; attempt < retries; attempt += 1) {
+        try {
+          const controller = new AbortController();
+          const timer = setTimeout(() => controller.abort(), timeout);
+          const response = await fetch(url, { headers: fullHeaders, signal: controller.signal });
+          clearTimeout(timer);
+          if (response.ok) return await response.json();
+        } catch (_err) {
+          if (attempt + 1 >= retries) return null;
+        }
+      }
+      return null;
+    }
+
+    return new Promise((resolve) => {
+      let attempts = 0;
+      function attempt() {
+        attempts += 1;
+        GM_xmlhttpRequest({
+          method: "GET",
+          url,
+          headers: fullHeaders,
+          timeout,
+          onload: (response) => {
+            if (response.status >= 200 && response.status < 300) {
+              try { resolve(JSON.parse(response.responseText)); }
+              catch (_err) { resolve(null); }
+            } else if (attempts < retries) {
+              attempt();
+            } else {
+              resolve(null);
+            }
+          },
+          onerror: () => { if (attempts < retries) attempt(); else resolve(null); },
+          ontimeout: () => { if (attempts < retries) attempt(); else resolve(null); },
+        });
+      }
+      attempt();
+    });
+  }
+
+  /**
    * Fetches organization name from PeeringDB API by organization ID.
    * Purpose: Resolve human-readable org names for network initialization.
    * Necessity: Network name should match org name; API lookup is more reliable than manual lookup.
@@ -1371,10 +1430,7 @@
     if (cached) return cached;
 
     try {
-      const response = await fetch(`https://www.peeringdb.com/api/org/${normalizedOrgId}`);
-      if (!response.ok) return null;
-
-      const payload = await response.json();
+      const payload = await pdbFetch(`https://www.peeringdb.com/api/org/${normalizedOrgId}`);
       const resolved = String(payload?.data?.[0]?.name || "").trim();
       if (!resolved) return null;
 
@@ -1822,30 +1878,12 @@
     }
 
     /**
-     * Fetches JSON from URL with proper headers and error handling.
-     * Purpose: Unified JSON request helper for RDAP API calls.
-     * Necessity: Uses Tampermonkey's GM_xmlhttpRequest for cross-origin CORS-free requests.
+     * Fetches JSON from URL using the shared pdbFetch client.
+     * Purpose: Delegate cross-origin RDAP requests to the unified network abstraction.
+     * Necessity: Centralises timeout, retry, and User-Agent header construction.
      */
     function requestJson(url) {
-      return new Promise((resolve) => {
-        GM_xmlhttpRequest({
-          method: "GET",
-          url,
-          headers: buildTampermonkeyRequestHeaders({ Accept: RDAP_ACCEPT_HEADER }),
-          onload: (response) => {
-            if (response.status >= 200 && response.status < 300) {
-              try {
-                resolve(JSON.parse(response.responseText));
-              } catch (_err) {
-                resolve(null);
-              }
-            } else {
-              resolve(null);
-            }
-          },
-          onerror: () => resolve(null),
-        });
-      });
+      return pdbFetch(url, { headers: { Accept: RDAP_ACCEPT_HEADER } });
     }
 
     /**

--- a/user.js/peeringdb-cp-consolidated-tools.user.js
+++ b/user.js/peeringdb-cp-consolidated-tools.user.js
@@ -1086,8 +1086,16 @@
     a.textContent = label;
     a.style.cursor = "pointer";
 
-    if (target) {
-      a.target = target;
+    const normalizedTarget = String(target || "").trim();
+    const requiresStableTarget =
+      Boolean(href && href !== "#") &&
+      (!normalizedTarget || normalizedTarget === "_new" || normalizedTarget === "_blank");
+    const effectiveTarget = requiresStableTarget
+      ? getStableToolbarLinkTarget(id)
+      : normalizedTarget;
+
+    if (effectiveTarget) {
+      a.target = effectiveTarget;
     }
 
     a.addEventListener("click", (event) => {
@@ -1100,8 +1108,8 @@
       if (href && href !== "#") {
         event.preventDefault();
         const resolvedUrl = new URL(href, window.location.origin).toString();
-        if (target && target !== "_self") {
-          window.open(resolvedUrl, target, "noopener");
+        if (effectiveTarget && effectiveTarget !== "_self") {
+          window.open(resolvedUrl, effectiveTarget, "noopener");
         } else {
           window.location.href = resolvedUrl;
         }
@@ -1130,7 +1138,7 @@
     return a;
   }
 
-  function createDropdownActionListItem({ id, label, items }) {
+  function createDropdownActionListItem({ id, label, items, resolveItemTarget = null }) {
     if (!id || !Array.isArray(items) || items.length === 0) return null;
     ensureDropdownGlobalCloseListener();
 
@@ -1160,11 +1168,17 @@
     menu.style.zIndex = "1000";
     menu.style.minWidth = "140px";
 
-    items.forEach((item) => {
+    items.forEach((item, index) => {
       const link = document.createElement("a");
       link.href = item.href;
       link.textContent = item.label;
-      link.target = item.target || "_blank";
+
+      const explicitTarget = String(item?.target || "").trim();
+      const computedTarget =
+        typeof resolveItemTarget === "function"
+          ? String(resolveItemTarget(item, index) || "").trim()
+          : "";
+      link.target = computedTarget || explicitTarget || "_blank";
       link.rel = "noopener noreferrer";
       link.style.display = "block";
       link.style.whiteSpace = "nowrap";
@@ -1217,7 +1231,20 @@
     const toolbar = getToolbarList();
     if (!toolbar) return null;
 
-    const dropdown = createDropdownActionListItem({ id, label, items });
+    const dropdown = createDropdownActionListItem({
+      id,
+      label,
+      items,
+      resolveItemTarget: (item, index) => {
+        const explicitTarget = String(item?.target || "").trim();
+        if (explicitTarget && explicitTarget !== "_new" && explicitTarget !== "_blank") {
+          return explicitTarget;
+        }
+
+        const itemToken = toStableIdentityToken(item?.label || item?.href || `item_${index + 1}`, `item_${index + 1}`);
+        return getStableToolbarLinkTarget(`${id}_${itemToken}`);
+      },
+    });
     if (!dropdown) return null;
 
     const { li, toggle } = dropdown;
@@ -1963,6 +1990,32 @@
   }
 
   /**
+   * Normalizes arbitrary text into a deterministic token usable in window target names.
+   * Purpose: Guarantee stable, safe target segments for toolbar links.
+   * Necessity: Prevents dynamic labels/IDs from creating invalid or inconsistent target names.
+   */
+  function toStableIdentityToken(value, fallback = "item") {
+    const normalized = String(value || "")
+      .trim()
+      .replace(/[^a-z0-9]+/gi, "_")
+      .replace(/^_+|_+$/g, "")
+      .toLowerCase();
+
+    return normalized || String(fallback || "item");
+  }
+
+  /**
+   * Builds deterministic target names for injected primary toolbar links.
+   * Purpose: Ensure all nav-header links open in stable, object-scoped tab identities.
+   * Necessity: Replaces ad-hoc _new/_blank targets with per-object deterministic targets.
+   */
+  function getStableToolbarLinkTarget(actionId, ctx = getRouteContext()) {
+    const grainyIdentity = toStableIdentityToken(getGrainyDerivedLinkIdentity(ctx), "entity");
+    const actionIdentity = toStableIdentityToken(actionId, "action");
+    return `pdb_${grainyIdentity}_${actionIdentity}`;
+  }
+
+  /**
    * Marks inline form rows (POCs, netfacs, netixlans) for deletion if status = 'deleted'.
    * Purpose: Clean up stale inline items when network status is deleted.
    * Necessity: Automatic cleanup prevents orphaned POCs/facilities when network is marked deleted.
@@ -2348,7 +2401,11 @@
               }
 
               const resolvedUrl = new URL(apiJsonUrl, window.location.origin).toString();
-              window.open(resolvedUrl, "_blank", "noopener");
+              const stableTarget =
+                event?.currentTarget?.target ||
+                event?.target?.target ||
+                getStableToolbarLinkTarget(`${MODULE_PREFIX}ApiJson`, ctx);
+              window.open(resolvedUrl, stableTarget, "noopener");
             },
           });
         }

--- a/user.js/peeringdb-cp-consolidated-tools.user.js
+++ b/user.js/peeringdb-cp-consolidated-tools.user.js
@@ -1906,6 +1906,25 @@
   }
 
   /**
+   * Reads a readonly field value from a form row by its visible label text.
+   * Purpose: Prefer values already rendered on the change form over stale API payloads.
+   * Necessity: Some readonly values can differ from API fetch timing/state on page load.
+   */
+  function getReadonlyFieldValueByLabel(labelText) {
+    const normalizedLabel = String(labelText || "").trim().toLowerCase();
+    if (!normalizedLabel) return "";
+
+    const row = qsa(".form-row").find((item) => {
+      const label = normalizeRenderedCopyText(
+        (qs(".c-1 label", item) || qs(".c-1", item))?.textContent || "",
+      ).toLowerCase();
+      return label === normalizedLabel;
+    });
+
+    return normalizeRenderedCopyText(qs(".grp-readonly", row)?.textContent || "");
+  }
+
+  /**
    * Marks inline form rows (POCs, netfacs, netixlans) for deletion if status = 'deleted'.
    * Purpose: Clean up stale inline items when network status is deleted.
    * Necessity: Automatic cleanup prevents orphaned POCs/facilities when network is marked deleted.
@@ -2667,12 +2686,15 @@
         try {
           const statusPayload = await pdbFetch(`https://www.peeringdb.com/api/net/${ctx.entityId}`);
           const netData = statusPayload?.data?.[0];
-          if (!netData || !netData.rir_status) return;
+          const formRirStatus = String(getReadonlyFieldValueByLabel("RIR status") || "").trim().toLowerCase();
+          const apiRirStatus = String(netData?.rir_status || "").trim().toLowerCase();
+          const status = formRirStatus || apiRirStatus;
+          if (!status) return;
 
-          const status = String(netData.rir_status || "").trim().toLowerCase();
           const statusColors = {
             ok: "#4caf50",
             invalid: "#f44336",
+            pending: "#ff9800",
             na: "#999",
           };
           const color = statusColors[status] || "#999";

--- a/user.js/peeringdb-cp-consolidated-tools.user.js
+++ b/user.js/peeringdb-cp-consolidated-tools.user.js
@@ -1720,7 +1720,7 @@
         addSecondaryActionButton({
           id: `${MODULE_PREFIX}UpdateEntityName`,
           label: "Update Name",
-          onClick: async () => {
+          onClick: async (event) => {
             const appendName = getNameSuffixForDeletedEntity(ctx.entityId);
             let baseName;
             if (["organization", "facility", "internetexchange"].includes(ctx.entity)) {
@@ -1730,8 +1730,19 @@
                 ? rawName.slice(0, -existingSuffix.length)
                 : rawName;
             } else {
+              const anchor = event?.target;
+              if (anchor) {
+                anchor.textContent = "Updating...";
+                anchor.style.opacity = "0.7";
+                anchor.style.pointerEvents = "none";
+              }
               const orgId = getOrganizationIdForNameUpdate(ctx);
               baseName = await getOrganizationName(orgId);
+              if (anchor) {
+                anchor.textContent = "Update Name";
+                anchor.style.opacity = "";
+                anchor.style.pointerEvents = "";
+              }
               if (!baseName) return;
             }
 
@@ -1811,6 +1822,29 @@
             }
           },
         });
+      },
+    },
+    {
+      id: "deleted-entity-highlight",
+      match: (ctx) => ctx.isEntityChangePage && ENTITY_TYPES.has(ctx.entity),
+      preconditions: () => Boolean(qs("#id_status") && qs("#grp-content")),
+      run: () => {
+        if (getSelectedStatus() !== "deleted") return;
+
+        const bgContainer = qs("#grp-content");
+        if (bgContainer) {
+          bgContainer.style.backgroundColor = "rgba(200, 30, 30, 0.07)";
+        }
+
+        const title = qs("#grp-content-title h1");
+        if (title && !qs(".pdb-deleted-badge", title)) {
+          const badge = document.createElement("span");
+          badge.className = "pdb-deleted-badge";
+          badge.style.cssText =
+            "margin-left:10px;color:#c0392b;font-weight:bold;font-size:0.8em;letter-spacing:0.05em;vertical-align:middle;";
+          badge.textContent = "DELETED";
+          title.appendChild(badge);
+        }
       },
     },
     {

--- a/user.js/peeringdb-cp-consolidated-tools.user.js
+++ b/user.js/peeringdb-cp-consolidated-tools.user.js
@@ -3211,7 +3211,14 @@
 
               const nextName = `${baseName}${appendName}`;
               const currentName = getInputValue("#id_name");
-              if (nextName === currentName) return;
+              if (nextName === currentName) {
+                pulseToolbarButton(event?.target, "No-op");
+                notifyUser({
+                  title: "PeeringDB CP",
+                  text: `Update Name: no changes required for '${nextName}'.`,
+                });
+                return;
+              }
 
               markDeletedNetworkInlinesForDeletion();
               setInputValue("#id_name", nextName);

--- a/user.js/peeringdb-cp-consolidated-tools.user.js
+++ b/user.js/peeringdb-cp-consolidated-tools.user.js
@@ -2655,6 +2655,56 @@
     });
   }
 
+  /**
+   * Runs a lightweight set of DOM precondition checks on page load.
+   * Purpose: Surface missing or renamed Django admin DOM landmarks early so
+   * regressions are caught immediately in the console rather than mid-action.
+   * Necessity: Grappelli admin markup can change between PeeringDB releases;
+   * a self-check surfaces breakage before a user triggers an action.
+   * Always logs to console.warn for any failed check; emits console.debug
+   * details in debug mode. Runs at most once per page load.
+   */
+  function runSelfCheck(ctx) {
+    const checks = [
+      { id: "grp-content",       selector: "#grp-content",             critical: true },
+      { id: "grp-content-title", selector: "#grp-content-title",       critical: true },
+      { id: "toolbar",           selector: () => Boolean(getToolbarList()), critical: false },
+      { id: "id_status",         selector: "#id_status",                critical: false },
+    ];
+
+    const failures = [];
+
+    checks.forEach(({ id, selector, critical }) => {
+      const found =
+        typeof selector === "function"
+          ? selector()
+          : Boolean(qs(selector));
+      dbg("self-check", `${found ? "ok" : "missing"} [${id}]`);
+      if (!found) failures.push({ id, critical });
+    });
+
+    if (failures.length === 0) {
+      dbg("self-check", "all checks passed", { entity: ctx.entity });
+      return;
+    }
+
+    const criticalIds = failures.filter((f) => f.critical).map((f) => f.id);
+    const warnIds    = failures.filter((f) => !f.critical).map((f) => f.id);
+
+    if (criticalIds.length) {
+      console.warn(
+        `[${MODULE_PREFIX}] self-check: critical landmarks missing — ${criticalIds.join(", ")}`,
+        { entity: ctx.entity, path: ctx.pathName },
+      );
+    }
+    if (warnIds.length) {
+      console.warn(
+        `[${MODULE_PREFIX}] self-check: optional landmarks missing — ${warnIds.join(", ")}`,
+        { entity: ctx.entity, path: ctx.pathName },
+      );
+    }
+  }
+
   function runConsolidatedInit() {
     const ctx = getRouteContext();
 
@@ -2662,6 +2712,7 @@
       return;
     }
 
+    runSelfCheck(ctx);
     cleanupLegacyPrimaryActionRow();
     dispatchModules(ctx);
     enforceToolbarButtonOrder(ctx);

--- a/user.js/peeringdb-cp-consolidated-tools.user.js
+++ b/user.js/peeringdb-cp-consolidated-tools.user.js
@@ -88,6 +88,41 @@
     `${MODULE_PREFIX}StatePending`,
     `${MODULE_PREFIX}StateDeleted`,
   ];
+
+  /**
+   * Entity types that derive their Update Name value from the current #id_name field
+   * rather than resolving it via the organization API.
+   */
+  const ENTITY_TYPES_OWN_NAME = new Set(["organization", "facility", "internetexchange"]);
+
+  /**
+   * Django admin inline-set DOM ID prefixes for network child relations.
+   * Used by markDeletedNetworkInlinesForDeletion to iterate all inline sets.
+   */
+  const NETWORK_INLINE_SET_PREFIXES = ["poc_set", "netfac_set", "netixlan_set"];
+
+  /**
+   * Deterministic left-to-right priority order for the primary CP toolbar.
+   * Items not matched by any entry are left in their original relative order.
+   */
+  const TOOLBAR_PRIMARY_ORDER = [
+    `li[data-pdb-cp-action="${MODULE_PREFIX}ResetNetworkInformation"]`,
+    `li[data-pdb-cp-action="${MODULE_PREFIX}Frontend"]`,
+    `li[data-pdb-cp-action="${MODULE_PREFIX}OrganizationFrontend"]`,
+    `li[data-pdb-cp-action="${MODULE_PREFIX}OrganizationCp"]`,
+    isHistoryToolbarItem,
+  ];
+
+  /**
+   * Deterministic left-to-right priority order for the secondary action row.
+   * Items not matched by any entry are left in their original relative order.
+   */
+  const TOOLBAR_SECONDARY_ORDER = [
+    `li[data-pdb-cp-secondary-action="${MODULE_PREFIX}UpdateEntityName"]`,
+    `li[data-pdb-cp-secondary-action="${MODULE_PREFIX}MapsDropdown"]`,
+    `li[data-pdb-cp-secondary-action="${MODULE_PREFIX}CopyEntityUrl"]`,
+    `li[data-pdb-cp-secondary-action="${MODULE_PREFIX}CopyOrganizationUrl"]`,
+  ];
   let dropdownGlobalCloseListenerBound = false;
 
   /**
@@ -1313,23 +1348,12 @@
 
     const primaryToolbar = getToolbarList();
     if (primaryToolbar) {
-      reorderChildrenByPriority(primaryToolbar, [
-        'li[data-pdb-cp-action="pdbCpConsolidatedResetNetworkInformation"]',
-        'li[data-pdb-cp-action="pdbCpConsolidatedFrontend"]',
-        'li[data-pdb-cp-action="pdbCpConsolidatedOrganizationFrontend"]',
-        'li[data-pdb-cp-action="pdbCpConsolidatedOrganizationCp"]',
-        isHistoryToolbarItem,
-      ]);
+      reorderChildrenByPriority(primaryToolbar, TOOLBAR_PRIMARY_ORDER);
     }
 
     const secondaryRow = qs(`#${MODULE_PREFIX}SecondaryActionRow`);
     if (secondaryRow) {
-      reorderChildrenByPriority(secondaryRow, [
-        'li[data-pdb-cp-secondary-action="pdbCpConsolidatedUpdateEntityName"]',
-        'li[data-pdb-cp-secondary-action="pdbCpConsolidatedMapsDropdown"]',
-        'li[data-pdb-cp-secondary-action="pdbCpConsolidatedCopyEntityUrl"]',
-        'li[data-pdb-cp-secondary-action="pdbCpConsolidatedCopyOrganizationUrl"]',
-      ]);
+      reorderChildrenByPriority(secondaryRow, TOOLBAR_SECONDARY_ORDER);
     }
   }
 
@@ -1754,9 +1778,7 @@
    * Necessity: Ensures consistent cleanup of deleted network members across all relation types.
    */
   function markDeletedNetworkInlinesForDeletion() {
-    clickDeleteHandlersForInlineSet("poc_set");
-    clickDeleteHandlersForInlineSet("netfac_set");
-    clickDeleteHandlersForInlineSet("netixlan_set");
+    NETWORK_INLINE_SET_PREFIXES.forEach((prefix) => clickDeleteHandlersForInlineSet(prefix));
   }
 
   // RDAP client module (fully isolated from feature modules)
@@ -2256,8 +2278,7 @@
     {
       id: "set-entity-name-equal-org-name",
       match: (ctx) =>
-        ctx.isEntityChangePage &&
-        ["network", "facility", "internetexchange", "organization", "carrier", "campus"].includes(ctx.entity),
+        ctx.isEntityChangePage && ENTITY_TYPES.has(ctx.entity),
       preconditions: (ctx) =>
         Boolean(
           getToolbarList() &&
@@ -2281,7 +2302,7 @@
             try {
               const appendName = getNameSuffixForDeletedEntity(ctx.entityId);
               let baseName;
-              if (["organization", "facility", "internetexchange"].includes(ctx.entity)) {
+              if (ENTITY_TYPES_OWN_NAME.has(ctx.entity)) {
                 const rawName = getInputValue("#id_name");
                 const existingSuffix = ` #${ctx.entityId}`;
                 baseName = rawName.endsWith(existingSuffix)

--- a/user.js/peeringdb-cp-consolidated-tools.user.js
+++ b/user.js/peeringdb-cp-consolidated-tools.user.js
@@ -40,6 +40,12 @@
   const DEFAULT_REQUEST_USER_AGENT = "PeeringDB-Admincom-CP-Consolidated";
   const ORG_NAME_CACHE_TTL_MS = 15 * 60 * 1000;
   const ORG_NAME_CACHE_STORAGE_PREFIX = `${MODULE_PREFIX}.orgNameCache.`;
+  /**
+   * Increment this integer whenever the shape of a stored org-name cache entry changes.
+   * On first read after a script update, any entry whose stored v field does not match
+   * is treated as stale and evicted, preventing silent misreads of old formats.
+   */
+  const ORG_NAME_CACHE_SCHEMA_VERSION = 1;
   const ENTITY_TYPES = new Set([
     "facility",
     "network",
@@ -420,7 +426,13 @@
       const parsed = JSON.parse(raw);
       const cachedName = String(parsed?.name || "").trim();
       const expiresAt = Number(parsed?.expiresAt || 0);
-      if (!cachedName || !Number.isFinite(expiresAt) || expiresAt <= now) {
+      const schemaVersion = Number(parsed?.v ?? -1);
+      if (
+        !cachedName ||
+        !Number.isFinite(expiresAt) ||
+        expiresAt <= now ||
+        schemaVersion !== ORG_NAME_CACHE_SCHEMA_VERSION
+      ) {
         window.sessionStorage?.removeItem(storageKey);
         return null;
       }
@@ -451,7 +463,7 @@
     try {
       window.sessionStorage?.setItem(
         storageKey,
-        JSON.stringify({ name: normalizedName, expiresAt }),
+        JSON.stringify({ v: ORG_NAME_CACHE_SCHEMA_VERSION, name: normalizedName, expiresAt }),
       );
     } catch (_error) {
       // sessionStorage may be unavailable; memory cache still provides benefit.

--- a/user.js/peeringdb-cp-consolidated-tools.user.js
+++ b/user.js/peeringdb-cp-consolidated-tools.user.js
@@ -89,6 +89,34 @@
   let dropdownGlobalCloseListenerBound = false;
 
   /**
+   * Computes a single EntityVisualState model for the current page context.
+   * Purpose: Provide one authoritative source of truth for all state-driven visuals.
+   * Necessity: Background, title markers, and future features derive from the same
+   * state data. Computing it once prevents drift and redundant DOM/field reads.
+   * @param {object} ctx - Route context from getRouteContext().
+   * @returns {{ state: string, entity: string, status: string,
+   *             isDummyChildFacility: boolean }}
+   */
+  function resolveEntityVisualState(ctx) {
+    const entity = String(ctx?.entity || "").trim().toLowerCase();
+    const status = String(getSelectedStatus() || "").trim().toLowerCase();
+    const orgId = Number.parseInt(getInputValue("#id_org"), 10);
+    const isDummyChildFacility =
+      entity === "facility" && Number.isFinite(orgId) && orgId === DUMMY_ORG_ID;
+
+    let state = "normal";
+    if (isDummyChildFacility) {
+      state = "dummy-child";
+    } else if (status === "pending") {
+      state = "pending";
+    } else if (status === "deleted") {
+      state = "deleted";
+    }
+
+    return { state, entity, status, isDummyChildFacility };
+  }
+
+  /**
    * Ensures CSS classes for entity-state background highlighting are available.
    * Purpose: Centralize state background colors in one style block instead of inline colors.
    * Necessity: Keeps state precedence predictable and easy to maintain across modules.
@@ -133,25 +161,17 @@
       bgContainer.classList.remove(className);
     });
 
-    const entity = String(ctx?.entity || "").trim().toLowerCase();
-    const status = String(getSelectedStatus() || "").trim().toLowerCase();
+    const { state } = resolveEntityVisualState(ctx);
 
-    const orgId = Number.parseInt(getInputValue("#id_org"), 10);
-    const isDummyChildFacility =
-      entity === "facility" && Number.isFinite(orgId) && orgId === DUMMY_ORG_ID;
+    const classMap = {
+      "dummy-child": `${MODULE_PREFIX}StateDummyChild`,
+      "pending":     `${MODULE_PREFIX}StatePending`,
+      "deleted":     `${MODULE_PREFIX}StateDeleted`,
+    };
 
-    if (isDummyChildFacility) {
-      bgContainer.classList.add(`${MODULE_PREFIX}StateDummyChild`);
-      return;
-    }
-
-    if (status === "pending") {
-      bgContainer.classList.add(`${MODULE_PREFIX}StatePending`);
-      return;
-    }
-
-    if (status === "deleted") {
-      bgContainer.classList.add(`${MODULE_PREFIX}StateDeleted`);
+    const targetClass = classMap[state];
+    if (targetClass) {
+      bgContainer.classList.add(targetClass);
     }
   }
 
@@ -164,17 +184,13 @@
     const title = qs("#grp-content-title h1");
     if (!title) return;
 
-    const entity = String(ctx?.entity || "").trim().toLowerCase();
-    const status = String(getSelectedStatus() || "").trim().toLowerCase();
-    const orgId = Number.parseInt(getInputValue("#id_org"), 10);
-    const isDummyChildFacility =
-      entity === "facility" && Number.isFinite(orgId) && orgId === DUMMY_ORG_ID;
+    const { state } = resolveEntityVisualState(ctx);
 
     const dummyMarkerClass = "pdb-dummy-org-child-marker";
     const deletedBadgeClass = "pdb-deleted-badge";
 
     const existingDummyMarker = qs(`.${dummyMarkerClass}`, title);
-    if (isDummyChildFacility) {
+    if (state === "dummy-child") {
       if (!existingDummyMarker) {
         const marker = document.createElement("span");
         marker.className = dummyMarkerClass;
@@ -188,7 +204,7 @@
     }
 
     const existingDeletedBadge = qs(`.${deletedBadgeClass}`, title);
-    if (status === "deleted") {
+    if (state === "deleted") {
       if (!existingDeletedBadge) {
         const badge = document.createElement("span");
         badge.className = deletedBadgeClass;

--- a/user.js/peeringdb-cp-consolidated-tools.user.js
+++ b/user.js/peeringdb-cp-consolidated-tools.user.js
@@ -1872,6 +1872,78 @@
   }
 
   /**
+   * Executes HTTP POST/PUT/PATCH/DELETE request to PeeringDB API.
+   * Purpose: Enable state-changing API operations (IXF import, carrierfac actions, etc.).
+   * Necessity: pdbFetch supports only GET; this handles mutations with method/body.
+   * Supports same-origin fetch and cross-origin GM_xmlhttpRequest delegation.
+   * Returns { status, data } on success (2xx), { status } on client/server error.
+   * @param {string} url - API endpoint URL.
+   * @param {string} method - HTTP method (POST, PUT, PATCH, DELETE).
+   * @param {string|object} body - Request body (string or JSON object).
+   * @param {{ headers?: object, contentType?: string, timeout?: number, retries?: number }} options
+   * @returns {Promise<{ status: number, data?: object|null }>} Response with status and optional parsed data.
+   */
+  async function pdbPost(url, method = "POST", body = "", { headers = {}, contentType = "application/json", timeout = 12000, retries = 1 } = {}) {
+    const fullMethod = String(method || "POST").toUpperCase();
+    const bodyString = typeof body === "string" ? body : JSON.stringify(body);
+    const fullHeaders = buildTampermonkeyRequestHeaders({ ...headers, "content-type": contentType });
+    let hostname = "";
+    try { hostname = new URL(url).hostname; } catch (_err) { /* keep empty hostname */ }
+    const isSameOrigin = hostname === window.location.hostname;
+
+    if (isSameOrigin) {
+      for (let attempt = 0; attempt < retries; attempt += 1) {
+        try {
+          const controller = new AbortController();
+          const timer = setTimeout(() => controller.abort(), timeout);
+          const response = await fetch(url, {
+            method: fullMethod,
+            headers: fullHeaders,
+            body: bodyString,
+            signal: controller.signal,
+          });
+          clearTimeout(timer);
+          let data = null;
+          try { data = await response.json(); } catch (_err) { /* ignore parse error */ }
+          if (response.ok) return { status: response.status, data };
+          return { status: response.status, data };
+        } catch (_err) {
+          if (attempt + 1 >= retries) return { status: 0, data: null };
+        }
+      }
+      return { status: 0, data: null };
+    }
+
+    return new Promise((resolve) => {
+      let attempts = 0;
+      function attempt() {
+        attempts += 1;
+        GM_xmlhttpRequest({
+          method: fullMethod,
+          url,
+          headers: fullHeaders,
+          data: bodyString,
+          timeout,
+          onload: (response) => {
+            let data = null;
+            try { data = JSON.parse(response.responseText); } catch (_err) { /* ignore parse error */ }
+            if (response.status >= 200 && response.status < 300) {
+              resolve({ status: response.status, data });
+            } else if (attempts < retries) {
+              attempt();
+            } else {
+              resolve({ status: response.status, data });
+            }
+          },
+          onerror: () => { if (attempts < retries) attempt(); else resolve({ status: 0, data: null }); },
+          ontimeout: () => { if (attempts < retries) attempt(); else resolve({ status: 0, data: null }); },
+        });
+      }
+      attempt();
+    });
+  }
+
+  /**
    * Fetches organization name for an entity from its API response.
    * Purpose: Optimize carrier/campus Update Name by reading org_name directly
    * from the entity response instead of making a separate /api/org/{id} call.

--- a/user.js/peeringdb-cp-consolidated-tools.user.js
+++ b/user.js/peeringdb-cp-consolidated-tools.user.js
@@ -221,43 +221,30 @@
   }
 
   /**
-   * Binds reactive listeners to keep entity-state backgrounds in sync with form edits.
-   * Purpose: Refresh state highlighting immediately when status/org values are changed by admins.
-   * Necessity: Without listeners, styling updates only on initial page load.
-   * Returns a dispose function that removes all registered listeners (lifecycle support).
+   * Subscribes to pdbBus status/org events to keep entity-state visuals in sync.
+   * Purpose: Refresh state highlighting when admins change status or org while editing.
+   * Necessity: Without listeners, styling only reflects the state at initial page load.
+   * Returns a dispose function that unsubscribes from the bus (lifecycle support).
    */
   function bindEntityStateBackgroundReactivity(ctx) {
     const statusSelect = qs("#id_status");
     if (!statusSelect || statusSelect.hasAttribute("data-pdb-cp-state-bg-bound")) return null;
-
     statusSelect.setAttribute("data-pdb-cp-state-bg-bound", "1");
 
-    const apply = () => {
+    const refresh = () => {
       scheduleDomUpdate("entity-state-visuals", () => {
         applyEntityStateBackgroundClass(ctx);
         syncEntityStateTitleMarkers(ctx);
       });
     };
 
-    statusSelect.addEventListener("change", apply);
-    statusSelect.addEventListener("input", apply);
-
-    const orgInput = qs("#id_org");
-    if (orgInput && !orgInput.hasAttribute("data-pdb-cp-state-bg-bound")) {
-      orgInput.setAttribute("data-pdb-cp-state-bg-bound", "1");
-      orgInput.addEventListener("change", apply);
-      orgInput.addEventListener("input", apply);
-    }
+    pdbBus.on("statusChanged", refresh);
+    pdbBus.on("orgChanged", refresh);
 
     return () => {
-      statusSelect.removeEventListener("change", apply);
-      statusSelect.removeEventListener("input", apply);
-      statusSelect.removeAttribute("data-pdb-cp-state-bg-bound");
-      if (orgInput) {
-        orgInput.removeEventListener("change", apply);
-        orgInput.removeEventListener("input", apply);
-        orgInput.removeAttribute("data-pdb-cp-state-bg-bound");
-      }
+      pdbBus.off("statusChanged", refresh);
+      pdbBus.off("orgChanged", refresh);
+      qs("#id_status")?.removeAttribute("data-pdb-cp-state-bg-bound");
     };
   }
 
@@ -662,6 +649,57 @@
       pendingDomUpdates.delete(key);
       if (typeof pending === "function") pending();
     });
+  }
+
+  /**
+   * Minimal internal publish/subscribe event bus for intra-script communication.
+   * Purpose: Decouple DOM event sources (status/org field changes) from feature
+   * subscribers so future modules attach to named events rather than raw DOM fields.
+   * Necessity: Prevents N-modules × 2-fields listener explosion; one DOM binding
+   * per field emits to all interested subscribers through the bus.
+   */
+  const pdbBus = (() => {
+    const listeners = new Map();
+    return {
+      on(event, handler) {
+        if (!listeners.has(event)) listeners.set(event, new Set());
+        listeners.get(event).add(handler);
+      },
+      off(event, handler) {
+        listeners.get(event)?.delete(handler);
+      },
+      emit(event, data) {
+        listeners.get(event)?.forEach((fn) => {
+          try { fn(data); } catch (_err) { /* subscriber errors must not break other subscribers */ }
+        });
+      },
+    };
+  })();
+
+  /**
+   * Attaches one-time DOM listeners on #id_status and #id_org, translating native
+   * change/input events into named pdbBus events (statusChanged, orgChanged).
+   * Purpose: Centralise the raw DOM fan-out so every subscriber avoids its own
+   * addEventListener call on the same elements.
+   * Necessity: Single DOM listener per field, many bus subscribers — O(1) DOM cost.
+   * Guarded by data-pdb-cp-bus-bound so safe to call from multiple modules.
+   */
+  function bindFormFieldBus() {
+    const statusSelect = qs("#id_status");
+    if (statusSelect && !statusSelect.hasAttribute("data-pdb-cp-bus-bound")) {
+      statusSelect.setAttribute("data-pdb-cp-bus-bound", "1");
+      const emitStatus = () => pdbBus.emit("statusChanged", { value: getSelectedStatus() });
+      statusSelect.addEventListener("change", emitStatus);
+      statusSelect.addEventListener("input", emitStatus);
+    }
+
+    const orgInput = qs("#id_org");
+    if (orgInput && !orgInput.hasAttribute("data-pdb-cp-bus-bound")) {
+      orgInput.setAttribute("data-pdb-cp-bus-bound", "1");
+      const emitOrg = () => pdbBus.emit("orgChanged", { value: getInputValue("#id_org") });
+      orgInput.addEventListener("change", emitOrg);
+      orgInput.addEventListener("input", emitOrg);
+    }
   }
 
   /**
@@ -2159,6 +2197,7 @@
       run: (ctx) => {
         applyEntityStateBackgroundClass(ctx);
         syncEntityStateTitleMarkers(ctx);
+        bindFormFieldBus();
         return bindEntityStateBackgroundReactivity(ctx);
       },
     },

--- a/user.js/peeringdb-cp-consolidated-tools.user.js
+++ b/user.js/peeringdb-cp-consolidated-tools.user.js
@@ -82,6 +82,7 @@
   const activeActionLocks = new Set();
   const openDropdownActionItems = new Set();
   const moduleDisposers = new Map();
+  const pendingDomUpdates = new Map();
   const ENTITY_STATE_BACKGROUND_CLASS_NAMES = [
     `${MODULE_PREFIX}StateDummyChild`,
     `${MODULE_PREFIX}StatePending`,
@@ -232,8 +233,10 @@
     statusSelect.setAttribute("data-pdb-cp-state-bg-bound", "1");
 
     const apply = () => {
-      applyEntityStateBackgroundClass(ctx);
-      syncEntityStateTitleMarkers(ctx);
+      scheduleDomUpdate("entity-state-visuals", () => {
+        applyEntityStateBackgroundClass(ctx);
+        syncEntityStateTitleMarkers(ctx);
+      });
     };
 
     statusSelect.addEventListener("change", apply);
@@ -638,6 +641,27 @@
       isEntityChangePage:
         path[0] === "cp" && path[1] === "peeringdb_server" && path[4] === "change",
     };
+  }
+
+  /**
+   * Schedules a keyed DOM write callback via requestAnimationFrame with deduplication.
+   * Purpose: Coalesce rapid event-driven DOM updates (e.g. typing in status/org) into a
+   * single paint frame, preventing redundant reflows per keypress.
+   * Necessity: Reactive listeners can fire dozens of times per second; batching keeps
+   * visual updates smooth without debounce latency.
+   * If a callback is already pending for the same key, the new fn replaces it.
+   */
+  function scheduleDomUpdate(key, fn) {
+    if (pendingDomUpdates.has(key)) {
+      pendingDomUpdates.set(key, fn);
+      return;
+    }
+    pendingDomUpdates.set(key, fn);
+    requestAnimationFrame(() => {
+      const pending = pendingDomUpdates.get(key);
+      pendingDomUpdates.delete(key);
+      if (typeof pending === "function") pending();
+    });
   }
 
   /**

--- a/user.js/peeringdb-cp-consolidated-tools.user.js
+++ b/user.js/peeringdb-cp-consolidated-tools.user.js
@@ -3248,6 +3248,80 @@
       },
     },
     {
+      id: "carrierfac-approve-reject",
+      match: (ctx) => ctx.isEntityChangePage && ctx.entity === "carrierfacility",
+      preconditions: () => Boolean(getToolbarList()),
+      run: (ctx) => {
+        const handleCarrierfacAction = async (action, event) => {
+          const actionLockKey = `${MODULE_PREFIX}.carrierfacAction.${action}.${ctx.entityId}`;
+          if (!tryBeginActionLock(actionLockKey)) {
+            notifyUser({
+              title: "PeeringDB CP",
+              text: `Carrier Facility ${action} is already running.`,
+            });
+            return;
+          }
+
+          try {
+            const button = event.target;
+            button.textContent = `${action}ing...`;
+            button.style.opacity = "0.7";
+            button.style.pointerEvents = "none";
+
+            const endpoint = `${PEERINGDB_API_BASE_URL}/carrierfac/${ctx.entityId}/${action.toLowerCase()}`;
+            const result = await pdbPost(endpoint, "POST", {});
+
+            if (result.status >= 200 && result.status < 300) {
+              notifyUser({
+                title: "PeeringDB CP",
+                text: `Carrier Facility ${action} succeeded.`,
+              });
+            } else {
+              notifyUser({
+                title: "PeeringDB CP",
+                text: `Carrier Facility ${action} failed (HTTP ${result.status}).`,
+              });
+            }
+          } catch (error) {
+            console.error(`[${MODULE_PREFIX}] Carrier Facility ${action} failed`, error);
+            notifyUser({
+              title: "PeeringDB CP",
+              text: `Carrier Facility ${action} failed. See console for details.`,
+            });
+          } finally {
+            const button = event?.target;
+            if (button) {
+              const origLabel = button.dataset.pdbCpOrigLabel || "Action";
+              button.textContent = origLabel;
+              button.style.opacity = "";
+              button.style.pointerEvents = "";
+            }
+            endActionLock(actionLockKey);
+          }
+        };
+
+        addToolbarAction({
+          id: `${MODULE_PREFIX}CarrierfacApprove`,
+          label: "Approve",
+          insertLeft: true,
+          onClick: (event) => {
+            event.target.dataset.pdbCpOrigLabel = "Approve";
+            handleCarrierfacAction("Approve", event);
+          },
+        });
+
+        addToolbarAction({
+          id: `${MODULE_PREFIX}CarrierfacReject`,
+          label: "Reject",
+          insertLeft: true,
+          onClick: (event) => {
+            event.target.dataset.pdbCpOrigLabel = "Reject";
+            handleCarrierfacAction("Reject", event);
+          },
+        });
+      },
+    },
+    {
       id: "request-ixf-import",
       match: (ctx) => ctx.isEntityChangePage && ctx.entity === "internetexchange",
       preconditions: () => Boolean(getToolbarList()),

--- a/user.js/peeringdb-cp-consolidated-tools.user.js
+++ b/user.js/peeringdb-cp-consolidated-tools.user.js
@@ -92,6 +92,7 @@
   const openDropdownActionItems = new Set();
   const moduleDisposers = new Map();
   const pendingDomUpdates = new Map();
+  const malformedApiPayloadWarnings = new Set();
   const ENTITY_STATE_BACKGROUND_CLASS_NAMES = [
     `${MODULE_PREFIX}StateDummyChild`,
     `${MODULE_PREFIX}StatePending`,
@@ -131,6 +132,21 @@
     ixlanprefix: "ixpfx",
     carrierfacility: "carrierfac",
   };
+  const OPENAPI_KNOWN_RESOURCE_SLUGS = new Set([
+    "org",
+    "fac",
+    "net",
+    "ix",
+    "carrier",
+    "campus",
+    "poc",
+    "netfac",
+    "netixlan",
+    "ixfac",
+    "ixlan",
+    "ixpfx",
+    "carrierfac",
+  ]);
 
   /**
    * Django admin inline-set DOM ID prefixes for network child relations.
@@ -1002,9 +1018,47 @@
    * Purpose: Standardize extraction of the first `data` row from API payloads.
    * Necessity: Reduces repeated optional-chaining logic and malformed-shape edge cases.
    */
-  function getFirstApiDataItem(payload) {
-    const rows = Array.isArray(payload?.data) ? payload.data : [];
+  function warnMalformedApiPayloadOnce(source, payload) {
+    if (!isDebugEnabled()) return;
+
+    const warningKey = String(source || "unknown").trim() || "unknown";
+    if (malformedApiPayloadWarnings.has(warningKey)) return;
+    malformedApiPayloadWarnings.add(warningKey);
+
+    console.warn(`[${MODULE_PREFIX}] Unexpected API payload shape at '${warningKey}'`, payload);
+  }
+
+  function getFirstApiDataItem(payload, source = "unknown") {
+    if (!payload || typeof payload !== "object") {
+      warnMalformedApiPayloadOnce(source, payload);
+      return null;
+    }
+
+    if (!Array.isArray(payload.data)) {
+      warnMalformedApiPayloadOnce(source, payload);
+      return null;
+    }
+
+    const rows = payload.data;
     return rows.length > 0 ? rows[0] : null;
+  }
+
+  /**
+   * Returns a reason code when API JSON action should be blocked.
+   * Purpose: Keep visibility and click-policy checks consistent.
+   * Necessity: Some entities may not expose status reliably; block only when policy-relevant.
+   */
+  function getApiJsonActionBlockReason(ctx) {
+    const apiJsonUrl = getEntityApiJsonUrl(ctx);
+    if (!apiJsonUrl) return "missing-endpoint";
+
+    const entity = String(ctx?.entity || "").trim().toLowerCase();
+    if (!ENTITY_TYPES.has(entity)) return "";
+
+    const status = String(getSelectedStatus() || "").trim().toLowerCase();
+    if (!status) return "";
+    if (status !== "ok") return `status:${status}`;
+    return "";
   }
 
   /**
@@ -1013,11 +1067,31 @@
    * Necessity: Prevent no-op UI affordances for non-OK entities.
    */
   function shouldShowApiJsonAction(ctx) {
-    const apiJsonUrl = getEntityApiJsonUrl(ctx);
-    if (!apiJsonUrl) return false;
+    return !getApiJsonActionBlockReason(ctx);
+  }
 
-    const status = String(getSelectedStatus() || "").trim().toLowerCase();
-    return status === "ok";
+  /**
+   * Debug-only OpenAPI coverage check for mapped CP API resources.
+   * Purpose: Catch accidental resource-slug typos or drift early in diagnostics mode.
+   * Necessity: ENTITY_API_RESOURCE_MAP is a critical integration point for API links/fetches.
+   */
+  function runApiResourceCoverageCheck() {
+    if (!isDebugEnabled()) return;
+
+    const mappedResources = Object.values(ENTITY_API_RESOURCE_MAP)
+      .map((slug) => String(slug || "").trim())
+      .filter(Boolean);
+
+    const unknownResources = mappedResources.filter((slug) => !OPENAPI_KNOWN_RESOURCE_SLUGS.has(slug));
+    if (unknownResources.length > 0) {
+      console.warn(
+        `[${MODULE_PREFIX}] self-check: unmapped OpenAPI resource slug(s) detected`,
+        unknownResources,
+      );
+      return;
+    }
+
+    dbg("self-check", "api resource coverage ok", { count: mappedResources.length });
   }
 
   function getEntityCopyLabel(entity) {
@@ -1619,7 +1693,7 @@
       if (!endpoint) return null;
 
       const payload = await pdbFetch(endpoint);
-      const entityData = getFirstApiDataItem(payload);
+      const entityData = getFirstApiDataItem(payload, endpoint);
       const resolved = String(entityData?.org_name || "").trim();
       if (!resolved) return null;
       return resolved;
@@ -1646,7 +1720,7 @@
       if (!endpoint) return null;
 
       const payload = await pdbFetch(endpoint);
-      const organizationData = getFirstApiDataItem(payload);
+      const organizationData = getFirstApiDataItem(payload, endpoint);
       const resolved = String(organizationData?.name || "").trim();
       if (!resolved) return null;
 
@@ -2483,9 +2557,12 @@
             target: "_new",
             insertLeft: true,
             onClick: (event) => {
-              const status = String(getSelectedStatus() || "").trim().toLowerCase();
-              if (status !== "ok") {
-                pulseToolbarButton(event?.target, `No-op (${status || "unknown"})`);
+              const blockReason = getApiJsonActionBlockReason(ctx);
+              if (blockReason) {
+                const label = blockReason.startsWith("status:")
+                  ? blockReason.slice("status:".length)
+                  : blockReason;
+                pulseToolbarButton(event?.target, `No-op (${label || "unknown"})`);
                 return;
               }
 
@@ -2859,7 +2936,7 @@
           if (!endpoint) return;
 
           const statusPayload = await pdbFetch(endpoint);
-          const ixData = getFirstApiDataItem(statusPayload);
+          const ixData = getFirstApiDataItem(statusPayload, endpoint);
           const formIxfStatus = String(
             getReadonlyFieldValueByLabel("Manual IX-F import status") ||
             getReadonlyFieldValueByLabel("IX-F import request status") ||
@@ -2915,7 +2992,7 @@
           if (!endpoint) return;
 
           const statusPayload = await pdbFetch(endpoint);
-          const netData = getFirstApiDataItem(statusPayload);
+          const netData = getFirstApiDataItem(statusPayload, endpoint);
           const formRirStatus = String(getReadonlyFieldValueByLabel("RIR status") || "").trim().toLowerCase();
           const apiRirStatus = String(netData?.rir_status || "").trim().toLowerCase();
           const status = formRirStatus || apiRirStatus;
@@ -3093,6 +3170,8 @@
    * details in debug mode. Runs at most once per page load.
    */
   function runSelfCheck(ctx) {
+    runApiResourceCoverageCheck();
+
     const checks = [
       { id: "grp-content",       selector: "#grp-content",             critical: true },
       { id: "grp-content-title", selector: "#grp-content-title",       critical: true },

--- a/user.js/peeringdb-cp-consolidated-tools.user.js
+++ b/user.js/peeringdb-cp-consolidated-tools.user.js
@@ -2569,6 +2569,51 @@
       },
     },
     {
+      id: "ixf-import-status-badge",
+      match: (ctx) => ctx.isEntityChangePage && ctx.entity === "internetexchange",
+      preconditions: () => Boolean(qs("#grp-content-title")),
+      run: async (ctx) => {
+        try {
+          const statusPayload = await pdbFetch(`https://www.peeringdb.com/api/ix/${ctx.entityId}`);
+          const ixData = statusPayload?.data?.[0];
+          if (!ixData || !ixData.ixf_import_request_status) return;
+
+          const status = String(ixData.ixf_import_request_status || "").trim().toLowerCase();
+          const statusColors = {
+            queued: "#ff9800",
+            importing: "#2196f3",
+            finished: "#4caf50",
+            error: "#f44336",
+          };
+          const color = statusColors[status] || "#999";
+          const lastImport = ixData.ixf_last_import ? new Date(ixData.ixf_last_import).toLocaleDateString() : "never";
+
+          const badge = document.createElement("span");
+          badge.style.cssText = `
+            display: inline-block;
+            padding: 2px 8px;
+            margin-left: 10px;
+            background-color: ${color};
+            color: white;
+            border-radius: 3px;
+            font-size: 12px;
+            font-weight: bold;
+            white-space: nowrap;
+            title: "Last import: ${lastImport}";
+          `;
+          badge.textContent = `IXF: ${status}`;
+          badge.title = `IXF import status: ${status}\nLast import: ${lastImport}`;
+
+          const titleArea = qs("#grp-content-title h1") || qs("#grp-content-title");
+          if (titleArea) {
+            titleArea.appendChild(badge);
+          }
+        } catch (_error) {
+          // Gracefully ignore API errors for status badge
+        }
+      },
+    },
+    {
       id: "set-window-title",
       match: (ctx) => ctx.isCp && ctx.isEntityChangePage,
       run: (ctx) => {

--- a/user.js/peeringdb-cp-consolidated-tools.user.js
+++ b/user.js/peeringdb-cp-consolidated-tools.user.js
@@ -40,6 +40,7 @@
     "localhost",
   ];
   const DEFAULT_REQUEST_USER_AGENT = "PeeringDB-Admincom-CP-Consolidated";
+  const PEERINGDB_API_BASE_URL = "https://www.peeringdb.com/api";
   const ORG_NAME_CACHE_TTL_MS = 15 * 60 * 1000;
   const ORG_NAME_CACHE_STORAGE_PREFIX = `${MODULE_PREFIX}.orgNameCache.`;
   /**
@@ -981,7 +982,29 @@
     const resource = getEntityApiResourceByEntity(ctx?.entity);
     const entityId = String(ctx?.entityId || "").trim();
     if (!resource || !entityId) return "";
-    return `https://www.peeringdb.com/api/${resource}/${entityId}`;
+    return `${PEERINGDB_API_BASE_URL}/${resource}/${entityId}`;
+  }
+
+  /**
+   * Builds a canonical PeeringDB API object URL for resource/id pairs.
+   * Purpose: Keep API endpoint construction centralized and consistent.
+   * Necessity: Avoids hardcoded URL drift across modules.
+   */
+  function getPeeringDbApiObjectUrl(resource, entityId) {
+    const normalizedResource = String(resource || "").trim();
+    const normalizedEntityId = String(entityId || "").trim();
+    if (!normalizedResource || !normalizedEntityId) return "";
+    return `${PEERINGDB_API_BASE_URL}/${normalizedResource}/${normalizedEntityId}`;
+  }
+
+  /**
+   * Safely returns the first object in PeeringDB list responses.
+   * Purpose: Standardize extraction of the first `data` row from API payloads.
+   * Necessity: Reduces repeated optional-chaining logic and malformed-shape edge cases.
+   */
+  function getFirstApiDataItem(payload) {
+    const rows = Array.isArray(payload?.data) ? payload.data : [];
+    return rows.length > 0 ? rows[0] : null;
   }
 
   /**
@@ -1592,8 +1615,12 @@
     if (!resource || !entityId) return null;
 
     try {
-      const payload = await pdbFetch(`https://www.peeringdb.com/api/${resource}/${entityId}`);
-      const resolved = String(payload?.data?.[0]?.org_name || "").trim();
+      const endpoint = getPeeringDbApiObjectUrl(resource, entityId);
+      if (!endpoint) return null;
+
+      const payload = await pdbFetch(endpoint);
+      const entityData = getFirstApiDataItem(payload);
+      const resolved = String(entityData?.org_name || "").trim();
       if (!resolved) return null;
       return resolved;
     } catch (_error) {
@@ -1615,8 +1642,12 @@
     if (cached) return cached;
 
     try {
-      const payload = await pdbFetch(`https://www.peeringdb.com/api/org/${normalizedOrgId}`);
-      const resolved = String(payload?.data?.[0]?.name || "").trim();
+      const endpoint = getPeeringDbApiObjectUrl("org", normalizedOrgId);
+      if (!endpoint) return null;
+
+      const payload = await pdbFetch(endpoint);
+      const organizationData = getFirstApiDataItem(payload);
+      const resolved = String(organizationData?.name || "").trim();
       if (!resolved) return null;
 
       setCachedOrganizationName(normalizedOrgId, resolved);
@@ -2824,8 +2855,11 @@
       preconditions: () => Boolean(qs("#grp-content-title")),
       run: async (ctx) => {
         try {
-          const statusPayload = await pdbFetch(`https://www.peeringdb.com/api/ix/${ctx.entityId}`);
-          const ixData = statusPayload?.data?.[0];
+          const endpoint = getPeeringDbApiObjectUrl("ix", ctx.entityId);
+          if (!endpoint) return;
+
+          const statusPayload = await pdbFetch(endpoint);
+          const ixData = getFirstApiDataItem(statusPayload);
           const formIxfStatus = String(
             getReadonlyFieldValueByLabel("Manual IX-F import status") ||
             getReadonlyFieldValueByLabel("IX-F import request status") ||
@@ -2877,8 +2911,11 @@
       preconditions: () => Boolean(qs("#grp-content-title")),
       run: async (ctx) => {
         try {
-          const statusPayload = await pdbFetch(`https://www.peeringdb.com/api/net/${ctx.entityId}`);
-          const netData = statusPayload?.data?.[0];
+          const endpoint = getPeeringDbApiObjectUrl("net", ctx.entityId);
+          if (!endpoint) return;
+
+          const statusPayload = await pdbFetch(endpoint);
+          const netData = getFirstApiDataItem(statusPayload);
           const formRirStatus = String(getReadonlyFieldValueByLabel("RIR status") || "").trim().toLowerCase();
           const apiRirStatus = String(netData?.rir_status || "").trim().toLowerCase();
           const status = formRirStatus || apiRirStatus;

--- a/user.js/peeringdb-cp-consolidated-tools.user.js
+++ b/user.js/peeringdb-cp-consolidated-tools.user.js
@@ -105,7 +105,7 @@
 
   /**
    * Unified entity slug mapping for frontend URLs and API resource paths.
-   * Both getFrontendSlugByEntity and getEntityApiResourceByEntity delegate to this map.
+   * getFrontendSlugByEntity delegates to this map.
    */
   const ENTITY_SLUG_MAP = {
     facility: "fac",
@@ -114,6 +114,21 @@
     carrier: "carrier",
     internetexchange: "ix",
     campus: "campus",
+  };
+
+  /**
+   * API resource mapping by CP entity type.
+   * Includes additional CP object types exposed by PeeringDB OpenAPI endpoints.
+   */
+  const ENTITY_API_RESOURCE_MAP = {
+    ...ENTITY_SLUG_MAP,
+    networkcontact: "poc",
+    networkfacility: "netfac",
+    networkixlan: "netixlan",
+    internetexchangefacility: "ixfac",
+    ixlan: "ixlan",
+    ixlanprefix: "ixpfx",
+    carrierfacility: "carrierfac",
   };
 
   /**
@@ -951,7 +966,7 @@
    * Necessity: CP workflows often require quick access to canonical API payloads.
    */
   function getEntityApiResourceByEntity(entity) {
-    return ENTITY_SLUG_MAP[entity] || "";
+    return ENTITY_API_RESOURCE_MAP[entity] || "";
   }
 
   /**
@@ -1852,8 +1867,24 @@
    * Necessity: Used to add " #deleted" suffix to entity names for deleted records.
    */
   function getSelectedStatus() {
-    const option = qs("#id_status > option:checked") || qs("#id_status > option[selected]");
-    return option ? String(option.getAttribute("value") || "") : "";
+    const statusSelect = qs("#id_status");
+    if (statusSelect) {
+      const option = qs("option:checked", statusSelect) || qs("option[selected]", statusSelect);
+      const value =
+        (option && String(option.getAttribute("value") || "").trim()) ||
+        String(statusSelect.value || "").trim();
+      if (value) return value;
+    }
+
+    const statusRow = qsa(".form-row").find((row) => {
+      const label = normalizeRenderedCopyText(
+        (qs(".c-1 label", row) || qs(".c-1", row))?.textContent || "",
+      ).toLowerCase();
+      return label === "status";
+    });
+
+    const readonlyStatus = normalizeRenderedCopyText(qs(".grp-readonly", statusRow)?.textContent || "");
+    return String(readonlyStatus || "").toLowerCase();
   }
 
   function getNameSuffixForDeletedEntity(entityId) {
@@ -2327,7 +2358,7 @@
     },
     {
       id: "entity-state-visuals",
-      match: (ctx) => ctx.isEntityChangePage && ENTITY_TYPES.has(ctx.entity),
+      match: (ctx) => ctx.isEntityChangePage,
       preconditions: () => Boolean(qs("#grp-content")),
       run: (ctx) => {
         applyEntityStateBackgroundClass(ctx);

--- a/user.js/peeringdb-cp-consolidated-tools.user.js
+++ b/user.js/peeringdb-cp-consolidated-tools.user.js
@@ -1448,6 +1448,7 @@
    * @returns {{ li: HTMLLIElement, toggle: HTMLAnchorElement }|null}
    */
   function createDropdownActionListItem({ id, label, items, resolveItemTarget = null }) {
+    if (!id || !Array.isArray(items) || items.length === 0) return null;
     ensureDropdownGlobalCloseListener();
 
     const li = document.createElement("li");
@@ -1538,6 +1539,7 @@
    * @returns {HTMLAnchorElement|null} The dropdown toggle anchor element, or null on failure.
    */
   function addToolbarDropdownAction({ id, label, items, insertLeft = false }) {
+    if (!id || !Array.isArray(items) || items.length === 0) return null;
 
     const existing = qs(`#${id}`);
     if (existing) {
@@ -3470,6 +3472,7 @@
    * regardless of DOMContentLoaded timing or future module additions.
    */
   function runConsolidatedInit() {
+    const ctx = getRouteContext();
 
     if (!ctx.isCp || !ctx.isEntityChangePage) {
       return;

--- a/user.js/peeringdb-cp-consolidated-tools.user.js
+++ b/user.js/peeringdb-cp-consolidated-tools.user.js
@@ -81,6 +81,7 @@
   const orgNameMemoryCache = new Map();
   const activeActionLocks = new Set();
   const openDropdownActionItems = new Set();
+  const moduleDisposers = new Map();
   const ENTITY_STATE_BACKGROUND_CLASS_NAMES = [
     `${MODULE_PREFIX}StateDummyChild`,
     `${MODULE_PREFIX}StatePending`,
@@ -219,13 +220,14 @@
   }
 
   /**
-   * Binds one-time reactive listeners to keep entity-state backgrounds in sync with form edits.
+   * Binds reactive listeners to keep entity-state backgrounds in sync with form edits.
    * Purpose: Refresh state highlighting immediately when status/org values are changed by admins.
    * Necessity: Without listeners, styling updates only on initial page load.
+   * Returns a dispose function that removes all registered listeners (lifecycle support).
    */
   function bindEntityStateBackgroundReactivity(ctx) {
     const statusSelect = qs("#id_status");
-    if (!statusSelect || statusSelect.hasAttribute("data-pdb-cp-state-bg-bound")) return;
+    if (!statusSelect || statusSelect.hasAttribute("data-pdb-cp-state-bg-bound")) return null;
 
     statusSelect.setAttribute("data-pdb-cp-state-bg-bound", "1");
 
@@ -243,6 +245,17 @@
       orgInput.addEventListener("change", apply);
       orgInput.addEventListener("input", apply);
     }
+
+    return () => {
+      statusSelect.removeEventListener("change", apply);
+      statusSelect.removeEventListener("input", apply);
+      statusSelect.removeAttribute("data-pdb-cp-state-bg-bound");
+      if (orgInput) {
+        orgInput.removeEventListener("change", apply);
+        orgInput.removeEventListener("input", apply);
+        orgInput.removeAttribute("data-pdb-cp-state-bg-bound");
+      }
+    };
   }
 
   /**
@@ -2122,7 +2135,7 @@
       run: (ctx) => {
         applyEntityStateBackgroundClass(ctx);
         syncEntityStateTitleMarkers(ctx);
-        bindEntityStateBackgroundReactivity(ctx);
+        return bindEntityStateBackgroundReactivity(ctx);
       },
     },
     {
@@ -2390,7 +2403,17 @@
         if (!isModuleEnabled(module.id, disabledModules)) return;
         if (!module.match(ctx)) return;
         if (typeof module.preconditions === "function" && !module.preconditions(ctx)) return;
-        module.run(ctx);
+
+        const existingDispose = moduleDisposers.get(module.id);
+        if (typeof existingDispose === "function") {
+          try { existingDispose(); } catch (_err) { /* ignore dispose errors */ }
+          moduleDisposers.delete(module.id);
+        }
+
+        const result = module.run(ctx);
+        if (typeof result === "function") {
+          moduleDisposers.set(module.id, result);
+        }
       } catch (error) {
         console.warn(`[${MODULE_PREFIX}] module failed: ${module.id}`, error);
       }

--- a/user.js/peeringdb-cp-consolidated-tools.user.js
+++ b/user.js/peeringdb-cp-consolidated-tools.user.js
@@ -81,7 +81,153 @@
   const orgNameMemoryCache = new Map();
   const activeActionLocks = new Set();
   const openDropdownActionItems = new Set();
+  const ENTITY_STATE_BACKGROUND_CLASS_NAMES = [
+    `${MODULE_PREFIX}StateDummyChild`,
+    `${MODULE_PREFIX}StatePending`,
+    `${MODULE_PREFIX}StateDeleted`,
+  ];
   let dropdownGlobalCloseListenerBound = false;
+
+  /**
+   * Ensures CSS classes for entity-state background highlighting are available.
+   * Purpose: Centralize state background colors in one style block instead of inline colors.
+   * Necessity: Keeps state precedence predictable and easy to maintain across modules.
+   */
+  function ensureEntityStateBackgroundStyles() {
+    const styleId = `${MODULE_PREFIX}EntityStateBackgroundStyle`;
+    if (document.getElementById(styleId)) return;
+
+    const style = document.createElement("style");
+    style.id = styleId;
+    style.textContent = `
+      #grp-content.${MODULE_PREFIX}StateDummyChild {
+        background-color: rgba(255, 235, 59, 0.22);
+      }
+
+      #grp-content.${MODULE_PREFIX}StatePending {
+        background-color: rgba(255, 152, 0, 0.16);
+      }
+
+      #grp-content.${MODULE_PREFIX}StateDeleted {
+        background-color: rgba(200, 30, 30, 0.1);
+      }
+    `;
+    document.head.appendChild(style);
+  }
+
+  /**
+   * Applies entity background-state class using explicit priority and entity scope.
+   * Priority (first match wins):
+   * 1) CHILD OF DUMMY ORGANIZATION (facility only)
+   * 2) pending (all entities)
+   * 3) deleted (all entities)
+   * Purpose: Align visual background behavior with policy-defined ordering.
+   * Necessity: Inline per-module background changes can conflict and obscure precedence.
+   */
+  function applyEntityStateBackgroundClass(ctx) {
+    const bgContainer = qs("#grp-content");
+    if (!bgContainer) return;
+
+    ensureEntityStateBackgroundStyles();
+    ENTITY_STATE_BACKGROUND_CLASS_NAMES.forEach((className) => {
+      bgContainer.classList.remove(className);
+    });
+
+    const entity = String(ctx?.entity || "").trim().toLowerCase();
+    const status = String(getSelectedStatus() || "").trim().toLowerCase();
+
+    const orgId = Number.parseInt(getInputValue("#id_org"), 10);
+    const isDummyChildFacility =
+      entity === "facility" && Number.isFinite(orgId) && orgId === DUMMY_ORG_ID;
+
+    if (isDummyChildFacility) {
+      bgContainer.classList.add(`${MODULE_PREFIX}StateDummyChild`);
+      return;
+    }
+
+    if (status === "pending") {
+      bgContainer.classList.add(`${MODULE_PREFIX}StatePending`);
+      return;
+    }
+
+    if (status === "deleted") {
+      bgContainer.classList.add(`${MODULE_PREFIX}StateDeleted`);
+    }
+  }
+
+  /**
+   * Synchronizes title markers for dummy-facility and deleted states.
+   * Purpose: Keep heading markers accurate as admins edit status/org fields in-place.
+   * Necessity: Marker rendering previously relied on module-local one-time insertions.
+   */
+  function syncEntityStateTitleMarkers(ctx) {
+    const title = qs("#grp-content-title h1");
+    if (!title) return;
+
+    const entity = String(ctx?.entity || "").trim().toLowerCase();
+    const status = String(getSelectedStatus() || "").trim().toLowerCase();
+    const orgId = Number.parseInt(getInputValue("#id_org"), 10);
+    const isDummyChildFacility =
+      entity === "facility" && Number.isFinite(orgId) && orgId === DUMMY_ORG_ID;
+
+    const dummyMarkerClass = "pdb-dummy-org-child-marker";
+    const deletedBadgeClass = "pdb-deleted-badge";
+
+    const existingDummyMarker = qs(`.${dummyMarkerClass}`, title);
+    if (isDummyChildFacility) {
+      if (!existingDummyMarker) {
+        const marker = document.createElement("span");
+        marker.className = dummyMarkerClass;
+        marker.style.cssText =
+          "margin-left:10px;color:red;font-weight:bold;font-size:0.8em;letter-spacing:0.02em;vertical-align:middle;";
+        marker.textContent = "CHILD OF DUMMY ORGANIZATION";
+        title.appendChild(marker);
+      }
+    } else if (existingDummyMarker) {
+      existingDummyMarker.remove();
+    }
+
+    const existingDeletedBadge = qs(`.${deletedBadgeClass}`, title);
+    if (status === "deleted") {
+      if (!existingDeletedBadge) {
+        const badge = document.createElement("span");
+        badge.className = deletedBadgeClass;
+        badge.style.cssText =
+          "margin-left:10px;color:#c0392b;font-weight:bold;font-size:0.8em;letter-spacing:0.05em;vertical-align:middle;";
+        badge.textContent = "DELETED";
+        title.appendChild(badge);
+      }
+    } else if (existingDeletedBadge) {
+      existingDeletedBadge.remove();
+    }
+  }
+
+  /**
+   * Binds one-time reactive listeners to keep entity-state backgrounds in sync with form edits.
+   * Purpose: Refresh state highlighting immediately when status/org values are changed by admins.
+   * Necessity: Without listeners, styling updates only on initial page load.
+   */
+  function bindEntityStateBackgroundReactivity(ctx) {
+    const statusSelect = qs("#id_status");
+    if (!statusSelect || statusSelect.hasAttribute("data-pdb-cp-state-bg-bound")) return;
+
+    statusSelect.setAttribute("data-pdb-cp-state-bg-bound", "1");
+
+    const apply = () => {
+      applyEntityStateBackgroundClass(ctx);
+      syncEntityStateTitleMarkers(ctx);
+    };
+
+    statusSelect.addEventListener("change", apply);
+    statusSelect.addEventListener("input", apply);
+
+    const orgInput = qs("#id_org");
+    if (orgInput && !orgInput.hasAttribute("data-pdb-cp-state-bg-bound")) {
+      orgInput.setAttribute("data-pdb-cp-state-bg-bound", "1");
+      orgInput.addEventListener("change", apply);
+      orgInput.addEventListener("input", apply);
+    }
+  }
 
   /**
    * Closes a single dropdown action item and resets its toggle accessibility state.
@@ -942,7 +1088,7 @@
    * Purpose: Add custom actions to secondary row with consistent styling.
    * Necessity: Secondary row actions need inline-block styling and spacing different from primary toolbar.
    */
-  function addSecondaryActionButton({ id, label, onClick }) {
+  function addSecondaryActionButton({ id, label, href = "#", title = "", onClick }) {
     const row = getOrCreateSecondaryActionRow();
     if (!row || !id) return null;
 
@@ -962,9 +1108,12 @@
 
     const button = document.createElement("a");
     button.id = id;
-    button.href = "#";
+    button.href = href || "#";
     button.textContent = label;
     button.style.cursor = "pointer";
+    if (title) {
+      button.title = title;
+    }
 
     if (typeof onClick === "function") {
       button.addEventListener("click", (event) => {
@@ -1087,7 +1236,6 @@
       reorderChildrenByPriority(secondaryRow, [
         'li[data-pdb-cp-secondary-action="pdbCpConsolidatedUpdateEntityName"]',
         'li[data-pdb-cp-secondary-action="pdbCpConsolidatedMapsDropdown"]',
-        'li[data-pdb-cp-secondary-action="pdbCpConsolidatedCopyEntityId"]',
         'li[data-pdb-cp-secondary-action="pdbCpConsolidatedCopyEntityUrl"]',
         'li[data-pdb-cp-secondary-action="pdbCpConsolidatedCopyOrganizationUrl"]',
       ]);
@@ -1853,16 +2001,8 @@
       match: (ctx) => ctx.isEntityChangePage,
       preconditions: () => Boolean(getToolbarList()),
       run: (ctx) => {
-        addSecondaryActionButton({
-          id: `${MODULE_PREFIX}CopyEntityId`,
-          label: `Copy ID ${ctx.entityId}`,
-          onClick: async (event) => {
-            const copied = await copyToClipboard(String(ctx.entityId || ""));
-            if (copied) {
-              pulseToolbarButton(event?.target, "Copied ID");
-            }
-          },
-        });
+        const entityPath = getEntityFrontendPath(ctx);
+        const entityUrl = entityPath ? `https://www.peeringdb.com${entityPath}` : "";
 
         const apiJsonUrl = getEntityApiJsonUrl(ctx);
         if (apiJsonUrl) {
@@ -1871,17 +2011,28 @@
             label: "API JSON",
             href: apiJsonUrl,
             target: "_new",
+            onClick: (event) => {
+              const status = String(getSelectedStatus() || "").trim().toLowerCase();
+              if (status !== "ok") {
+                pulseToolbarButton(event?.target, `No-op (${status || "unknown"})`);
+                return;
+              }
+
+              const resolvedUrl = new URL(apiJsonUrl, window.location.origin).toString();
+              window.open(resolvedUrl, "_blank", "noopener");
+            },
           });
         }
 
-        const entityPath = getEntityFrontendPath(ctx);
-        if (entityPath) {
+        if (entityUrl) {
+          const entityCopyLabel = `${getEntityCopyLabel(ctx.entity)} #${ctx.entityId}`;
           addSecondaryActionButton({
             id: `${MODULE_PREFIX}CopyEntityUrl`,
-            label: getEntityCopyLabel(ctx.entity),
+            label: entityCopyLabel,
+            href: entityUrl,
+            title: entityUrl,
             onClick: async (event) => {
-              const url = `https://www.peeringdb.com${entityPath}`;
-              const copied = await copyToClipboard(url);
+              const copied = await copyToClipboard(entityUrl);
               if (copied) {
                 pulseToolbarButton(event?.target, "Copied URL");
               }
@@ -1892,12 +2043,15 @@
         const orgId = ctx.entity === "organization" ? "" : getInputValue("#id_org");
         if (!orgId) return;
 
+        const orgUrl = `https://www.peeringdb.com/org/${orgId}`;
+
         addSecondaryActionButton({
           id: `${MODULE_PREFIX}CopyOrganizationUrl`,
-          label: "Copy Org URL",
+          label: `Copy Org URL #${orgId}`,
+          href: orgUrl,
+          title: orgUrl,
           onClick: async (event) => {
-            const url = `https://www.peeringdb.com/org/${orgId}`;
-            const copied = await copyToClipboard(url);
+            const copied = await copyToClipboard(orgUrl);
             if (copied) {
               pulseToolbarButton(event?.target, "Copied Org URL");
             }
@@ -1946,24 +2100,13 @@
       },
     },
     {
-      id: "highlight-dummy-org-child",
-      match: (ctx) => ctx.isEntityChangePage && ctx.entity === "facility",
-      preconditions: () => Boolean(qs("#id_org") && qs("#grp-content-title h1") && qs("#grp-content")),
-      run: () => {
-        const orgId = parseInt(getInputValue("#id_org"), 10);
-        if (!Number.isFinite(orgId) || orgId !== DUMMY_ORG_ID) return;
-
-        const title = qs("#grp-content-title h1");
-        const bgContainer = qs("#grp-content");
-
-        if (title && !title.textContent.includes("CHILD OF DUMMY ORGANIZATION")) {
-          title.innerHTML +=
-            '<span style="text-align:center;color:red;font-weight:bold;"> CHILD OF DUMMY ORGANIZATION</span>';
-        }
-
-        if (bgContainer) {
-          bgContainer.style.backgroundColor = "rgba(255, 255, 0, 0.5)";
-        }
+      id: "entity-state-visuals",
+      match: (ctx) => ctx.isEntityChangePage && ENTITY_TYPES.has(ctx.entity),
+      preconditions: () => Boolean(qs("#grp-content")),
+      run: (ctx) => {
+        applyEntityStateBackgroundClass(ctx);
+        syncEntityStateTitleMarkers(ctx);
+        bindEntityStateBackgroundReactivity(ctx);
       },
     },
     {
@@ -2193,29 +2336,6 @@
             }
           },
         });
-      },
-    },
-    {
-      id: "deleted-entity-highlight",
-      match: (ctx) => ctx.isEntityChangePage && ENTITY_TYPES.has(ctx.entity),
-      preconditions: () => Boolean(qs("#id_status") && qs("#grp-content")),
-      run: () => {
-        if (getSelectedStatus() !== "deleted") return;
-
-        const bgContainer = qs("#grp-content");
-        if (bgContainer) {
-          bgContainer.style.backgroundColor = "rgba(200, 30, 30, 0.07)";
-        }
-
-        const title = qs("#grp-content-title h1");
-        if (title && !qs(".pdb-deleted-badge", title)) {
-          const badge = document.createElement("span");
-          badge.className = "pdb-deleted-badge";
-          badge.style.cssText =
-            "margin-left:10px;color:#c0392b;font-weight:bold;font-size:0.8em;letter-spacing:0.05em;vertical-align:middle;";
-          badge.textContent = "DELETED";
-          title.appendChild(badge);
-        }
       },
     },
     {

--- a/user.js/peeringdb-cp-consolidated-tools.user.js
+++ b/user.js/peeringdb-cp-consolidated-tools.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         PeeringDB CP - Consolidated Tools
 // @namespace    https://www.peeringdb.com/cp/
-// @version      1.0.50.20260323
+// @version      2.0.0.20260323
 // @description  Consolidated CP userscript with strict route-isolated modules for facility/network/user/entity workflows
 // @author       <chriztoffer@peeringdb.com>
 // @match        https://www.peeringdb.com/cp/peeringdb_server/*
@@ -25,7 +25,7 @@
   "use strict";
 
   const MODULE_PREFIX = "pdbCpConsolidated";
-  const SCRIPT_VERSION = "1.0.50.20260323";
+  const SCRIPT_VERSION = "2.0.0.20260323";
   const DUMMY_ORG_ID = 20525;
   const DISABLED_MODULES_STORAGE_KEY = `${MODULE_PREFIX}.disabledModules`;
   const USER_AGENT_STORAGE_KEY = `${MODULE_PREFIX}.userAgent`;

--- a/user.js/peeringdb-cp-consolidated-tools.user.js
+++ b/user.js/peeringdb-cp-consolidated-tools.user.js
@@ -233,6 +233,34 @@
   }
 
   /**
+   * Clears all organization-name cache entries from memory and session storage.
+   * Purpose: Provide explicit cache invalidation control for stale org-name lookups.
+   * Necessity: Admin workflows occasionally require immediate refresh after org renames.
+   */
+  function clearOrganizationNameCache() {
+    orgNameMemoryCache.clear();
+
+    try {
+      const storage = window.sessionStorage;
+      if (!storage) return;
+
+      const keysToDelete = [];
+      for (let index = 0; index < storage.length; index += 1) {
+        const key = storage.key(index);
+        if (key && key.startsWith(ORG_NAME_CACHE_STORAGE_PREFIX)) {
+          keysToDelete.push(key);
+        }
+      }
+
+      keysToDelete.forEach((key) => {
+        storage.removeItem(key);
+      });
+    } catch (_error) {
+      // Ignore storage failures; in-memory cache is still cleared.
+    }
+  }
+
+  /**
    * Retrieves the set of disabled module IDs from localStorage.
    * Purpose: Allows individual modules to be toggled on/off without code changes.
    * Necessity: Provides user-level module control for the modular architecture.
@@ -1451,6 +1479,8 @@
       ttlMs: 6 * 60 * 60 * 1000,
       payload: null,
     };
+    const resolvedOrgNameCacheByAsn = new Map();
+    const resolvedOrgNameCacheTtlMs = 15 * 60 * 1000;
 
     /**
      * Parses and validates ASN from string input.
@@ -1650,6 +1680,15 @@
       const asn = parseAsn(asnInput);
       if (!asn) return null;
 
+      const cached = resolvedOrgNameCacheByAsn.get(asn);
+      if (cached && cached.expiresAt > Date.now() && cached.name) {
+        return cached.name;
+      }
+
+      if (cached && cached.expiresAt <= Date.now()) {
+        resolvedOrgNameCacheByAsn.delete(asn);
+      }
+
       console.log(`[rdapAutnumClient] Requesting RDAP for AS${asn}...`);
 
       try {
@@ -1659,6 +1698,10 @@
         const name = resolveOrganizationNameFromAutnumPayload(payload);
         if (name) {
           console.log(`[rdapAutnumClient] Successfully resolved AS${asn}: ${name}`);
+          resolvedOrgNameCacheByAsn.set(asn, {
+            name,
+            expiresAt: Date.now() + resolvedOrgNameCacheTtlMs,
+          });
         }
         return name;
       } catch (_error) {
@@ -1667,8 +1710,20 @@
       }
     }
 
+    /**
+     * Clears RDAP bootstrap and resolved-name caches.
+     * Purpose: Allow explicit invalidation from user commands after external data changes.
+     * Necessity: Manual cache reset is useful for debugging and immediate refresh scenarios.
+     */
+    function clearCache() {
+      bootstrapCache.loadedAt = 0;
+      bootstrapCache.payload = null;
+      resolvedOrgNameCacheByAsn.clear();
+    }
+
     return {
       resolveOrganizationNameByAsn,
+      clearCache,
     };
   })();
 
@@ -2127,6 +2182,22 @@
 
     GM_registerMenuCommand("CP: Reset Information", () => {
       qs(`#${MODULE_PREFIX}ResetNetworkInformation`)?.click();
+    });
+
+    GM_registerMenuCommand("CP: Clear Org Name Cache", () => {
+      clearOrganizationNameCache();
+      notifyUser({
+        title: "PeeringDB CP",
+        text: "Organization-name cache cleared.",
+      });
+    });
+
+    GM_registerMenuCommand("CP: Clear RDAP Cache", () => {
+      rdapAutnumClient.clearCache();
+      notifyUser({
+        title: "PeeringDB CP",
+        text: "RDAP caches cleared.",
+      });
     });
   }
 

--- a/user.js/peeringdb-cp-consolidated-tools.user.js
+++ b/user.js/peeringdb-cp-consolidated-tools.user.js
@@ -3275,6 +3275,27 @@
           if (titleArea) {
             titleArea.appendChild(badge);
           }
+
+          // Append IRR AS-SET badge using the already-fetched network data.
+          // Purpose: Surface the IRR route-object set identifier without a second API call.
+          const irrAsSet = String(netData?.irr_as_set || "").trim();
+          if (irrAsSet && titleArea) {
+            const irrBadge = document.createElement("span");
+            irrBadge.style.cssText = `
+              display: inline-block;
+              padding: 2px 8px;
+              margin-left: 6px;
+              background-color: #607d8b;
+              color: white;
+              border-radius: 3px;
+              font-size: 12px;
+              font-weight: bold;
+              white-space: nowrap;
+            `;
+            irrBadge.textContent = `IRR: ${irrAsSet}`;
+            irrBadge.title = `IRR AS-SET: ${irrAsSet}`;
+            titleArea.appendChild(irrBadge);
+          }
         } catch (_error) {
           // Gracefully ignore API errors for status badge
         }

--- a/user.js/peeringdb-cp-consolidated-tools.user.js
+++ b/user.js/peeringdb-cp-consolidated-tools.user.js
@@ -1465,6 +1465,27 @@
   }
 
   /**
+   * Fetches organization name for an entity from its API response.
+   * Purpose: Optimize carrier/campus Update Name by reading org_name directly
+   * from the entity response instead of making a separate /api/org/{id} call.
+   * Necessity: Carrier and Campus schemas include org_name as a readOnly field.
+   * Returns null on network error or missing data (graceful degradation).
+   */
+  async function getOrganizationNameFromEntityApi(entity, entityId) {
+    const resource = getEntityApiResourceByEntity(entity);
+    if (!resource || !entityId) return null;
+
+    try {
+      const payload = await pdbFetch(`https://www.peeringdb.com/api/${resource}/${entityId}`);
+      const resolved = String(payload?.data?.[0]?.org_name || "").trim();
+      if (!resolved) return null;
+      return resolved;
+    } catch (_error) {
+      return null;
+    }
+  }
+
+  /**
    * Fetches organization name from PeeringDB API by organization ID.
    * Purpose: Resolve human-readable org names for network initialization.
    * Necessity: Network name should match org name; API lookup is more reliable than manual lookup.
@@ -2407,8 +2428,12 @@
                   anchor.style.opacity = "0.7";
                   anchor.style.pointerEvents = "none";
                 }
-                const orgId = getOrganizationIdForNameUpdate(ctx);
-                baseName = await getOrganizationName(orgId);
+                if (ctx.entity === "carrier" || ctx.entity === "campus") {
+                  baseName = await getOrganizationNameFromEntityApi(ctx.entity, ctx.entityId);
+                } else {
+                  const orgId = getOrganizationIdForNameUpdate(ctx);
+                  baseName = await getOrganizationName(orgId);
+                }
                 if (anchor) {
                   anchor.textContent = "Update Name";
                   anchor.style.opacity = "";

--- a/user.js/peeringdb-cp-consolidated-tools.user.js
+++ b/user.js/peeringdb-cp-consolidated-tools.user.js
@@ -41,8 +41,16 @@
   ];
   const DEFAULT_REQUEST_USER_AGENT = "PeeringDB-Admincom-CP-Consolidated";
   const PEERINGDB_API_BASE_URL = "https://www.peeringdb.com/api";
-  const ORG_NAME_CACHE_TTL_MS = 15 * 60 * 1000;
+  const CACHE_TTL_MS = 7.5 * 60 * 60 * 1000;
+  const ORG_NAME_CACHE_TTL_MS = CACHE_TTL_MS;
   const ORG_NAME_CACHE_STORAGE_PREFIX = `${MODULE_PREFIX}.orgNameCache.`;
+  const NETWORK_NAME_SCAN_CACHE_KEY = `${MODULE_PREFIX}.networkNameScanCache.v8`;
+  const NETWORK_NAME_SCAN_CACHE_TTL_MS = CACHE_TTL_MS;
+  const NETWORK_NAME_SCAN_PAGE_SIZE = 2000;
+  const NETWORK_NAME_SCAN_TARGET_COUNT = 0;
+  const NETWORK_NAME_SCAN_MAX_REQUESTS = 40;
+  const NETWORK_NAME_SCAN_MIN_SUSPICIOUS_SCORE = 4;
+  const NETWORK_NAME_SCAN_HIGH_CONFIDENCE_MIN_SCORE = 6;
   /**
    * Increment this integer whenever the shape of a stored org-name cache entry changes.
    * On first read after a script update, any entry whose stored v field does not match
@@ -475,6 +483,29 @@
   }
 
   /**
+   * Returns storage for domain-scoped cache entries.
+   * Purpose: Share short-lived cache payloads across tabs on the same origin.
+   * Necessity: sessionStorage is tab-scoped; localStorage enables cross-tab reuse.
+   * Falls back to sessionStorage when localStorage is unavailable.
+   * @returns {Storage|null} localStorage (preferred), sessionStorage (fallback), or null.
+   */
+  function getDomainCacheStorage() {
+    try {
+      if (window.localStorage) return window.localStorage;
+    } catch (_error) {
+      // Fall through to sessionStorage fallback.
+    }
+
+    try {
+      if (window.sessionStorage) return window.sessionStorage;
+    } catch (_error) {
+      // Ignore; cache persistence will be unavailable.
+    }
+
+    return null;
+  }
+
+  /**
    * Normalizes organization ID into a stable cache key suffix.
    * Purpose: Ensure cache keys are deterministic across string/number ID inputs.
    * Necessity: Different call sites may pass IDs with whitespace or mixed types.
@@ -486,11 +517,11 @@
   }
 
   /**
-   * Builds sessionStorage key used for persisted org-name cache entries.
+   * Builds storage key used for persisted org-name cache entries.
    * Purpose: Keep all org-name cache keys namespaced under module prefix.
    * Necessity: Avoid collisions with other userscripts and local app storage keys.
    * @param {string|number} orgId - Organization ID to build the key for.
-   * @returns {string} Namespaced sessionStorage key, or empty string if orgId is invalid.
+   * @returns {string} Namespaced storage key, or empty string if orgId is invalid.
    */
   function getOrgNameCacheStorageKey(orgId) {
     const normalizedOrgId = normalizeOrgIdForCache(orgId);
@@ -499,7 +530,7 @@
   }
 
   /**
-   * Reads a valid organization-name cache entry from in-memory or session storage.
+   * Reads a valid organization-name cache entry from in-memory or domain storage.
    * Purpose: Reuse recent org-name lookups to reduce repeated API requests.
    * Necessity: Update Name and Reset Information may request the same org repeatedly.
    * Returns null when cache is absent, malformed, or expired.
@@ -525,7 +556,8 @@
     if (!storageKey) return null;
 
     try {
-      const raw = window.sessionStorage?.getItem(storageKey);
+      const storage = getDomainCacheStorage();
+      const raw = storage?.getItem(storageKey);
       if (!raw) return null;
 
       const parsed = JSON.parse(raw);
@@ -538,7 +570,7 @@
         expiresAt <= now ||
         schemaVersion !== ORG_NAME_CACHE_SCHEMA_VERSION
       ) {
-        window.sessionStorage?.removeItem(storageKey);
+        storage?.removeItem(storageKey);
         return null;
       }
 
@@ -550,7 +582,7 @@
   }
 
   /**
-   * Stores organization-name cache entry in memory and session storage.
+   * Stores organization-name cache entry in memory and domain storage.
    * Purpose: Persist successful org-name lookups for current tab lifecycle.
    * Necessity: Avoid duplicate network requests for frequently used org IDs.
    * @param {string|number} orgId - Organization ID to cache the name for.
@@ -568,17 +600,18 @@
     if (!storageKey) return;
 
     try {
-      window.sessionStorage?.setItem(
+      const storage = getDomainCacheStorage();
+      storage?.setItem(
         storageKey,
         JSON.stringify({ v: ORG_NAME_CACHE_SCHEMA_VERSION, name: normalizedName, expiresAt }),
       );
     } catch (_error) {
-      // sessionStorage may be unavailable; memory cache still provides benefit.
+      // Storage may be unavailable; memory cache still provides benefit.
     }
   }
 
   /**
-   * Clears all organization-name cache entries from memory and session storage.
+   * Clears all organization-name cache entries from memory and domain storage.
    * Purpose: Provide explicit cache invalidation control for stale org-name lookups.
    * Necessity: Admin workflows occasionally require immediate refresh after org renames.
    */
@@ -586,7 +619,7 @@
     orgNameMemoryCache.clear();
 
     try {
-      const storage = window.sessionStorage;
+      const storage = getDomainCacheStorage();
       if (!storage) return;
 
       const keysToDelete = [];
@@ -2126,6 +2159,502 @@
   }
 
   /**
+   * Builds a PeeringDB list API URL with query parameters.
+   * Purpose: Centralize URL construction for sparse list retrieval calls.
+   * Necessity: Reused by REST fallback and future bulk list scanners.
+   * @param {string} resource - API resource slug (e.g., "net").
+   * @param {Record<string, string|number|boolean|undefined|null>} [params={}] - Query parameter map.
+   * @returns {string} Absolute URL string.
+   */
+  function buildPeeringDbListApiUrl(resource, params = {}) {
+    const normalizedResource = String(resource || "").trim();
+    if (!normalizedResource) return "";
+
+    const url = new URL(`${PEERINGDB_API_BASE_URL}/${normalizedResource}`);
+    Object.entries(params).forEach(([key, value]) => {
+      if (value === undefined || value === null || value === "") return;
+      url.searchParams.set(key, String(value));
+    });
+    return url.toString();
+  }
+
+  /**
+   * Normalizes API row objects into minimal network scan records.
+   * Purpose: Keep name-pattern analysis independent of source transport shape.
+   * Necessity: GraphQL and REST rows can differ slightly in key casing/types.
+   * @param {object} row - Source row object.
+   * @returns {{ id: string, name: string }|null} Normalized record or null.
+   */
+  function normalizeNetworkNameRecord(row) {
+    if (!row || typeof row !== "object") return null;
+    const id = String(row.id || row.pk || "").trim();
+    const name = String(row.name || "").trim();
+    if (!id || !name) return null;
+    return { id, name };
+  }
+
+  /**
+   * Parses GraphQL response payload into normalized network records.
+   * Purpose: Support multiple plausible GraphQL response envelopes safely.
+   * Necessity: GraphQL schema details can vary; parser must be tolerant.
+   * @param {object|null} payload - GraphQL response payload.
+   * @returns {{ id: string, name: string }[]} Parsed records.
+   */
+  function parseGraphQlNetworkRows(payload) {
+    const data = payload && typeof payload === "object" ? payload.data : null;
+    if (!data || typeof data !== "object") return [];
+
+    const candidateContainers = [
+      data.networks,
+      data.network,
+      data.networksConnection,
+      data.net,
+    ].filter(Boolean);
+
+    const extractedRows = [];
+
+    candidateContainers.forEach((container) => {
+      if (Array.isArray(container)) {
+        extractedRows.push(...container);
+        return;
+      }
+
+      if (Array.isArray(container?.edges)) {
+        container.edges.forEach((edge) => {
+          if (edge?.node) extractedRows.push(edge.node);
+        });
+      }
+
+      if (Array.isArray(container?.items)) {
+        extractedRows.push(...container.items);
+      }
+
+      if (Array.isArray(container?.nodes)) {
+        extractedRows.push(...container.nodes);
+      }
+    });
+
+    return extractedRows
+      .map((row) => normalizeNetworkNameRecord(row))
+      .filter(Boolean);
+  }
+
+  /**
+   * Executes one GraphQL network-name batch query via GET.
+   * Purpose: Retrieve only id/name fields with schema-driven sparse selection.
+   * Necessity: Keeps payload minimal and reusable for future GraphQL extensions.
+   * @param {{ offset: number, limit: number }} opts - Pagination options.
+   * @returns {Promise<{ id: string, name: string }[]|null>} Parsed rows or null when unavailable.
+   */
+  async function fetchGraphQlNetworkNameBatch({ offset, limit }) {
+    const endpoint = `${window.location.origin}/api/graphql`;
+    const query = `query NetworkNameBatch($first: Int!, $offset: Int!) {\n  networks(first: $first, offset: $offset, status: \"ok\") {\n    edges {\n      node {\n        id\n        name\n      }\n    }\n  }\n}`;
+    const variables = { first: limit, offset };
+
+    const url = `${endpoint}?query=${encodeURIComponent(query)}&variables=${encodeURIComponent(JSON.stringify(variables))}`;
+    const payload = await pdbFetch(url, {
+      headers: {
+        Accept: "application/json",
+      },
+      timeout: 15000,
+      retries: 1,
+    });
+    if (!payload) return null;
+    if (payload.errors && Array.isArray(payload.errors) && payload.errors.length > 0) return null;
+
+    const rows = parseGraphQlNetworkRows(payload);
+    return rows.length ? rows : null;
+  }
+
+  /**
+   * Executes one REST network-name batch query with sparse fields.
+   * Purpose: Reliable fallback when GraphQL endpoint is unavailable.
+   * Necessity: Guarantees completion under strict request budgets.
+   * @param {{ offset: number, limit: number }} opts - Pagination options.
+   * @returns {Promise<{ id: string, name: string }[]>} Parsed rows.
+   */
+  async function fetchRestNetworkNameBatch({ offset, limit }) {
+    const url = buildPeeringDbListApiUrl("net", {
+      status: "ok",
+      limit,
+      skip: offset,
+      depth: 0,
+      fields: "id,name",
+    });
+    if (!url) return [];
+
+    const payload = await pdbFetch(url, {
+      headers: {
+        Accept: "application/json",
+      },
+      timeout: 15000,
+      retries: 1,
+    });
+
+    const rows = Array.isArray(payload?.data) ? payload.data : [];
+    return rows
+      .map((row) => normalizeNetworkNameRecord(row))
+      .filter(Boolean);
+  }
+
+  /**
+   * Retrieves recent network names in fixed-size batches with minimal request count.
+   * Purpose: Fetch up to 3000 names in 6 requests (500 each) under strict rate limits.
+   * Necessity: Supports CP-side operational audits without backend tooling.
+   * GraphQL is attempted once first; automatic REST fallback is used thereafter.
+   * @param {{
+   *   targetCount?: number,
+   *   pageSize?: number,
+   *   requestLimit?: number,
+   *   onProgress?: Function,
+   * }} [opts]
+   * @returns {Promise<{
+   *   records: Array<{id: string, name: string}>,
+   *   requestCount: number,
+   *   transport: string,
+   *   graphQlAttempted: boolean,
+   * }>} Retrieval result.
+   */
+  async function fetchRecentNetworkNamesBatched(opts = {}) {
+    const requestedTargetCount = Number(opts.targetCount ?? NETWORK_NAME_SCAN_TARGET_COUNT);
+    const isTargetUnbounded = !Number.isFinite(requestedTargetCount) || requestedTargetCount <= 0;
+    const targetCount = isTargetUnbounded
+      ? Number.POSITIVE_INFINITY
+      : Math.max(1, Math.floor(requestedTargetCount));
+    const pageSize = Math.max(1, Math.floor(Number(opts.pageSize || NETWORK_NAME_SCAN_PAGE_SIZE)));
+    const requestLimit = Math.max(1, Math.floor(Number(opts.requestLimit || NETWORK_NAME_SCAN_MAX_REQUESTS)));
+    const onProgress = typeof opts.onProgress === "function" ? opts.onProgress : null;
+
+    const totalBatches = Number.isFinite(targetCount) ? Math.ceil(targetCount / pageSize) : null;
+    const records = [];
+    const seenIds = new Set();
+    let requestCount = 0;
+    let graphQlAttempted = false;
+    let graphQlEnabled = true;
+    let transport = "rest";
+    let batchIndex = 0;
+    let offset = 0;
+
+    while (requestCount < requestLimit && records.length < targetCount) {
+      let rows = [];
+
+      if (graphQlEnabled) {
+        graphQlAttempted = true;
+        const graphQlRows = await fetchGraphQlNetworkNameBatch({ offset, limit: pageSize });
+        requestCount += 1;
+        if (Array.isArray(graphQlRows) && graphQlRows.length > 0) {
+          rows = graphQlRows;
+          transport = "graphql";
+        } else {
+          graphQlEnabled = false;
+          if (requestCount >= requestLimit) break;
+          rows = await fetchRestNetworkNameBatch({ offset, limit: pageSize });
+          requestCount += 1;
+          transport = "rest";
+        }
+      } else {
+        rows = await fetchRestNetworkNameBatch({ offset, limit: pageSize });
+        requestCount += 1;
+      }
+
+      rows.forEach((row) => {
+        if (records.length >= targetCount) return;
+        if (seenIds.has(row.id)) return;
+        seenIds.add(row.id);
+        records.push(row);
+      });
+
+      if (onProgress) {
+        onProgress({
+          batchIndex: batchIndex + 1,
+          totalBatches,
+          recordsFetched: records.length,
+          requestCount,
+          transport,
+        });
+      }
+
+      batchIndex += 1;
+      offset += rows.length;
+
+      if (rows.length === 0) break;
+    }
+
+    return { records, requestCount, transport, graphQlAttempted, totalBatches, isTargetUnbounded };
+  }
+
+  /**
+   * Classifies one network name for likely auto-generated patterns.
+   * Purpose: Prioritize names likely requiring manual "Update Name" remediation.
+   * Necessity: Provides deterministic, extensible heuristics for operational triage.
+   * @param {string} name - Network name string.
+   * @returns {{ score: number, reasons: string[] }} Classification result.
+   */
+  function classifyNetworkNamePattern(name) {
+    const normalized = String(name || "").trim();
+    if (!normalized) return { score: 0, reasons: [] };
+
+    const reasons = [];
+    let score = 0;
+    const addReason = (reason, weight) => {
+      reasons.push(reason);
+      score += weight;
+    };
+
+    const letters = (normalized.match(/[A-Za-z]/g) || []).length;
+    const digits = (normalized.match(/\d/g) || []).length;
+    const alphaNumTotal = letters + digits;
+    const digitRatio = alphaNumTotal > 0 ? digits / alphaNumTotal : 0;
+
+    const hasNumericOnly = /^\d{4,}$/.test(normalized);
+    const hasAsnToken = /^(?:AS|ASN)[-_ ]?\d{2,}$/i.test(normalized);
+    const hasOrgToken = /^ORG-[A-Z0-9-]{4,}$/i.test(normalized);
+    const hasGenericPrefixNumber = /^(?:NET|NETWORK|IX|CARRIER|FACILITY|CAMPUS)[-_ ]?\d{2,}$/i.test(normalized);
+    const hasPlaceholderKeyword = /\b(?:test|dummy|temp|example|placeholder)\b/i.test(normalized);
+    const hasDigitHeavy = digitRatio >= 0.60 && normalized.length >= 6;
+    const hasLowAlphaSignal = letters <= 2 && normalized.length >= 7;
+    const hasTokenLike = /^[A-Z0-9_-]{8,}$/.test(normalized) && !/\s/.test(normalized);
+
+    if (hasNumericOnly) addReason("numeric-only", 5);
+    if (hasPlaceholderKeyword) addReason("placeholder-keyword", 5);
+    if (hasAsnToken) addReason("asn-token", 3);
+    if (hasOrgToken) addReason("org-token", 3);
+    if (hasGenericPrefixNumber) addReason("generic-prefix+number", 2);
+    if (hasDigitHeavy) addReason("digit-heavy", 1);
+    if (hasLowAlphaSignal) addReason("low-alpha-signal", 1);
+    if (hasTokenLike) addReason("token-like", 2);
+
+    return { score, reasons };
+  }
+
+  /**
+   * Analyzes network-name records and returns pattern diagnostics.
+   * Purpose: Produce ranked candidate set and aggregate reason counts.
+   * Necessity: Converts raw names into actionable remediation targets.
+   * @param {Array<{id: string, name: string}>} records - Retrieved network records.
+   * @returns {{
+   *   scannedAt: string,
+   *   total: number,
+   *   suspiciousCount: number,
+   *   suspicious: Array<{id: string, name: string, score: number, reasons: string[], changeUrl: string}>,
+   *   reasonCounts: Record<string, number>,
+   * }} Analysis payload.
+   */
+  function analyzeNetworkNamePatterns(records) {
+    const inputRows = Array.isArray(records) ? records : [];
+    const reasonCounts = {};
+    const highConfidence = [];
+    const review = [];
+    const reviewThreshold = NETWORK_NAME_SCAN_MIN_SUSPICIOUS_SCORE;
+    const highConfidenceThreshold = Math.max(
+      reviewThreshold,
+      NETWORK_NAME_SCAN_HIGH_CONFIDENCE_MIN_SCORE,
+    );
+
+    const sortByScoreAndIdDesc = (a, b) => {
+      if (b.score !== a.score) return b.score - a.score;
+      const aDigits = Number.parseInt(String(a.id), 10);
+      const bDigits = Number.parseInt(String(b.id), 10);
+      if (Number.isFinite(aDigits) && Number.isFinite(bDigits)) {
+        return bDigits - aDigits;
+      }
+      return String(b.id).localeCompare(String(a.id));
+    };
+
+    inputRows.forEach((row) => {
+      const item = normalizeNetworkNameRecord(row);
+      if (!item) return;
+
+      const { score, reasons } = classifyNetworkNamePattern(item.name);
+      reasons.forEach((reason) => {
+        reasonCounts[reason] = (reasonCounts[reason] || 0) + 1;
+      });
+
+      if (score >= highConfidenceThreshold) {
+        highConfidence.push({
+          ...item,
+          tier: "high-confidence",
+          score,
+          reasons,
+          changeUrl: `${window.location.origin}/cp/peeringdb_server/network/${item.id}/change/`,
+        });
+        return;
+      }
+
+      if (score >= reviewThreshold) {
+        review.push({
+          ...item,
+          tier: "review",
+          score,
+          reasons,
+          changeUrl: `${window.location.origin}/cp/peeringdb_server/network/${item.id}/change/`,
+        });
+      }
+    });
+
+    highConfidence.sort(sortByScoreAndIdDesc);
+    review.sort(sortByScoreAndIdDesc);
+
+    const suspicious = [...highConfidence, ...review];
+
+    return {
+      scannedAt: new Date().toISOString(),
+      total: inputRows.length,
+      highConfidenceCount: highConfidence.length,
+      reviewCount: review.length,
+      suspiciousCount: suspicious.length,
+      highConfidence,
+      review,
+      suspicious,
+      reasonCounts,
+    };
+  }
+
+  /**
+   * Returns a compact human-readable summary for notifications/logging.
+   * Purpose: Surface key scan outcomes without requiring table inspection.
+   * Necessity: Enables quick operator feedback after long-running scans.
+   * @param {object} result - Combined retrieval + analysis result.
+   * @returns {string} One-line summary.
+   */
+  function buildNetworkNamePatternSummary(result) {
+    const total = Number(result?.analysis?.total || 0);
+    const highConfidenceCount = Number(result?.analysis?.highConfidenceCount || 0);
+    const reviewCount = Number(result?.analysis?.reviewCount || 0);
+    const suspiciousCount = Number(result?.analysis?.suspiciousCount || 0);
+    const requestCount = Number(result?.requestCount || 0);
+    const transport = String(result?.transport || "rest").toUpperCase();
+    const source = String(result?.source || "fresh").toLowerCase() === "cache" ? "cache" : "fresh fetch";
+    return `Scanned ${total} network names in ${requestCount} request${requestCount === 1 ? "" : "s"} (${transport}, ${source}); flagged ${suspiciousCount} names (${highConfidenceCount} high-confidence, ${reviewCount} review).`;
+  }
+
+  /**
+   * Reads cached network-name scan retrieval payload when still fresh.
+   * Purpose: Reuse previously fetched network rows without re-calling list endpoints.
+   * Necessity: Re-runs should execute analysis heuristics against the same cached row set
+   * while TTL is valid, and refetch only when TTL expires.
+   * @returns {object|null} Cached retrieval payload or null.
+   */
+  function getCachedNetworkNameScanData() {
+    try {
+      const storage = getDomainCacheStorage();
+      const raw = storage?.getItem(NETWORK_NAME_SCAN_CACHE_KEY);
+      if (!raw) return null;
+
+      const parsed = JSON.parse(raw);
+      const expiresAt = Number(parsed?.expiresAt || 0);
+      if (!Number.isFinite(expiresAt) || Date.now() >= expiresAt) {
+        storage?.removeItem(NETWORK_NAME_SCAN_CACHE_KEY);
+        return null;
+      }
+
+      const payload = parsed?.payload;
+      if (!payload || typeof payload !== "object") return null;
+      if (!Array.isArray(payload.records)) return null;
+      return payload;
+    } catch (_error) {
+      return null;
+    }
+  }
+
+  /**
+   * Stores network-name scan retrieval payload in short-lived domain cache.
+   * Purpose: Cache full fetched row list once, then reuse for repeated analysis runs.
+   * Necessity: Keeps scan cost low while allowing threshold/heuristic reruns within TTL.
+   * @param {object} payload - Retrieval payload including records + transport metadata.
+   */
+  function setCachedNetworkNameScanData(payload) {
+    try {
+      const storage = getDomainCacheStorage();
+      storage?.setItem(
+        NETWORK_NAME_SCAN_CACHE_KEY,
+        JSON.stringify({
+          expiresAt: Date.now() + NETWORK_NAME_SCAN_CACHE_TTL_MS,
+          payload,
+        }),
+      );
+    } catch (_error) {
+      // Ignore cache-write failures.
+    }
+  }
+
+  /**
+   * Builds TSV text for suspicious network-name candidates.
+   * Purpose: Provide copy-pastable remediation worklist for manual update runs.
+   * Necessity: Operators frequently move candidate sets between browser and spreadsheets.
+   * @param {{ suspicious: Array<{id: string, name: string, reasons: string[], changeUrl: string}> }} analysis - Analysis payload.
+   * @returns {string} TSV output string.
+   */
+  function buildSuspiciousNetworkNameTsv(analysis) {
+    const rows = Array.isArray(analysis?.suspicious) ? analysis.suspicious : [];
+    const header = ["id", "name", "tier", "score", "reasons", "change_url"].join("\t");
+    const lines = rows.map((item) => {
+      const id = String(item?.id || "").trim();
+      const name = String(item?.name || "").trim().replace(/\s+/g, " ");
+      const tier = String(item?.tier || "review").trim();
+      const score = String(item?.score ?? "").trim();
+      const reasons = Array.isArray(item?.reasons) ? item.reasons.join(",") : "";
+      const changeUrl = String(item?.changeUrl || "").trim();
+      return [id, name, tier, score, reasons, changeUrl].join("\t");
+    });
+    return [header, ...lines].join("\n");
+  }
+
+  /**
+   * Emits structured network-name diagnostics to the console.
+   * Purpose: Keep detailed pattern evidence available without cluttering notifications.
+   * Necessity: Manual cleanup planning benefits from sortable tables and reason distributions.
+   * @param {{
+   *   requestCount: number,
+   *   transport: string,
+   *   graphQlAttempted: boolean,
+   *   analysis: object,
+   * }} result - Combined retrieval+analysis result.
+   */
+  function logNetworkNamePatternDiagnostics(result) {
+    const analysis = result?.analysis || {};
+    const suspicious = Array.isArray(analysis.suspicious) ? analysis.suspicious : [];
+    const highConfidenceCount = Number(analysis.highConfidenceCount || 0);
+    const reviewCount = Number(analysis.reviewCount || 0);
+    const reasonCounts = analysis.reasonCounts || {};
+    const reasonRows = Object.entries(reasonCounts)
+      .map(([reason, count]) => ({ reason, count }))
+      .sort((a, b) => b.count - a.count);
+
+    console.group(`[${MODULE_PREFIX}] Network name scan diagnostics`);
+    console.info(buildNetworkNamePatternSummary(result));
+    console.info({
+      scannedAt: analysis.scannedAt,
+      total: analysis.total,
+      highConfidenceCount,
+      reviewCount,
+      suspiciousCount: analysis.suspiciousCount,
+      source: String(result?.source || "fresh"),
+      requestCount: result?.requestCount,
+      transport: result?.transport,
+      graphQlAttempted: Boolean(result?.graphQlAttempted),
+    });
+
+    if (reasonRows.length) {
+      console.table(reasonRows);
+    }
+
+    if (suspicious.length) {
+      const preview = suspicious.slice(0, 200).map((item) => ({
+        id: item.id,
+        name: item.name,
+        tier: item.tier,
+        score: item.score,
+        reasons: item.reasons.join(", "),
+        changeUrl: item.changeUrl,
+      }));
+      console.table(preview);
+    }
+
+    console.groupEnd();
+  }
+
+  /**
    * Shows a non-blocking userscript notification when supported.
    * Purpose: Surface completion/failure status for long-running CP actions.
    * Necessity: Async updates may complete after several network calls and benefit from toasts.
@@ -2904,6 +3433,109 @@
   // (ctx predicate), and run (ctx handler that may return a dispose function).
   // ---------------------------------------------------------------------------
   const modules = [
+    {
+      id: "network-name-pattern-diagnostics",
+      match: (ctx) => ctx.isEntityListPage && ctx.entity === "network",
+      preconditions: () => Boolean(getToolbarList()),
+      run: () => {
+        addToolbarAction({
+          id: `${MODULE_PREFIX}AnalyzeNetworkNames`,
+          label: "Analyze names",
+          insertLeft: true,
+          onClick: async (event) => {
+            const actionLockKey = `${MODULE_PREFIX}.analyzeNetworkNames`;
+            if (!tryBeginActionLock(actionLockKey)) {
+              notifyUser({
+                title: "PeeringDB CP",
+                text: "Network name analysis is already running.",
+              });
+              return;
+            }
+
+            const button = event?.target;
+            const setButtonText = (text) => {
+              if (!button) return;
+              button.textContent = text;
+            };
+            let postRunButtonText = "Analyze names";
+            let postRunButtonDelayMs = 0;
+
+            try {
+              if (button) {
+                button.style.opacity = "0.7";
+                button.style.pointerEvents = "none";
+              }
+
+              let retrieval = getCachedNetworkNameScanData();
+              const usedCache = Boolean(retrieval);
+              if (!retrieval) {
+                setButtonText("Scanning...");
+                retrieval = await fetchRecentNetworkNamesBatched({
+                  targetCount: NETWORK_NAME_SCAN_TARGET_COUNT,
+                  pageSize: NETWORK_NAME_SCAN_PAGE_SIZE,
+                  requestLimit: NETWORK_NAME_SCAN_MAX_REQUESTS,
+                  onProgress: ({ batchIndex, totalBatches, recordsFetched }) => {
+                    if (Number.isFinite(totalBatches)) {
+                      setButtonText(`Scanning ${batchIndex}/${totalBatches}`);
+                      return;
+                    }
+                    setButtonText(`Scanning ${batchIndex} (${recordsFetched})`);
+                  },
+                });
+
+                setCachedNetworkNameScanData(retrieval);
+              }
+
+              setButtonText("Analyzing...");
+              const analysis = analyzeNetworkNamePatterns(retrieval.records);
+              const result = {
+                ...retrieval,
+                source: usedCache ? "cache" : "fresh",
+                analysis,
+              };
+
+              logNetworkNamePatternDiagnostics(result);
+
+              const summary = buildNetworkNamePatternSummary(result);
+              const suspiciousTsv = buildSuspiciousNetworkNameTsv(result.analysis);
+              if (suspiciousTsv) {
+                await copyToClipboard(suspiciousTsv);
+              }
+
+              setButtonText(usedCache ? "Cached" : "Fetched");
+              postRunButtonDelayMs = 900;
+              notifyUser({
+                title: "PeeringDB CP",
+                text: `${summary} Candidate TSV copied to clipboard.`,
+                timeout: 4000,
+              });
+            } catch (error) {
+              console.error(`[${MODULE_PREFIX}] Network name analysis failed`, error);
+              setButtonText("Scan failed");
+              postRunButtonDelayMs = 1200;
+              notifyUser({
+                title: "PeeringDB CP",
+                text: "Network name analysis failed. See console for details.",
+              });
+            } finally {
+              if (button) {
+                button.style.opacity = "";
+                button.style.pointerEvents = "";
+
+                if (postRunButtonDelayMs > 0) {
+                  setTimeout(() => {
+                    button.textContent = postRunButtonText;
+                  }, postRunButtonDelayMs);
+                } else {
+                  button.textContent = postRunButtonText;
+                }
+              }
+              endActionLock(actionLockKey);
+            }
+          },
+        });
+      },
+    },
     {
       id: "copy-overview-change-links",
       match: (ctx) => ctx.isEntityListPage,

--- a/user.js/peeringdb-cp-consolidated-tools.user.js
+++ b/user.js/peeringdb-cp-consolidated-tools.user.js
@@ -36,6 +36,8 @@
     "localhost",
   ];
   const DEFAULT_REQUEST_USER_AGENT = "PeeringDB-Admincom-CP-Consolidated";
+  const ORG_NAME_CACHE_TTL_MS = 15 * 60 * 1000;
+  const ORG_NAME_CACHE_STORAGE_PREFIX = `${MODULE_PREFIX}.orgNameCache.`;
   const ENTITY_TYPES = new Set([
     "facility",
     "network",
@@ -74,6 +76,96 @@
     "policy email",
     "sales email",
   ]);
+  const orgNameMemoryCache = new Map();
+
+  /**
+   * Normalizes organization ID into a stable cache key suffix.
+   * Purpose: Ensure cache keys are deterministic across string/number ID inputs.
+   * Necessity: Different call sites may pass IDs with whitespace or mixed types.
+   */
+  function normalizeOrgIdForCache(orgId) {
+    return String(orgId || "").trim();
+  }
+
+  /**
+   * Builds sessionStorage key used for persisted org-name cache entries.
+   * Purpose: Keep all org-name cache keys namespaced under module prefix.
+   * Necessity: Avoid collisions with other userscripts and local app storage keys.
+   */
+  function getOrgNameCacheStorageKey(orgId) {
+    const normalizedOrgId = normalizeOrgIdForCache(orgId);
+    if (!normalizedOrgId) return "";
+    return `${ORG_NAME_CACHE_STORAGE_PREFIX}${normalizedOrgId}`;
+  }
+
+  /**
+   * Reads a valid organization-name cache entry from in-memory or session storage.
+   * Purpose: Reuse recent org-name lookups to reduce repeated API requests.
+   * Necessity: Update Name and Reset Information may request the same org repeatedly.
+   * Returns null when cache is absent, malformed, or expired.
+   */
+  function getCachedOrganizationName(orgId) {
+    const normalizedOrgId = normalizeOrgIdForCache(orgId);
+    if (!normalizedOrgId) return null;
+
+    const now = Date.now();
+
+    const memoryEntry = orgNameMemoryCache.get(normalizedOrgId);
+    if (memoryEntry && memoryEntry.expiresAt > now && memoryEntry.name) {
+      return memoryEntry.name;
+    }
+
+    if (memoryEntry && memoryEntry.expiresAt <= now) {
+      orgNameMemoryCache.delete(normalizedOrgId);
+    }
+
+    const storageKey = getOrgNameCacheStorageKey(normalizedOrgId);
+    if (!storageKey) return null;
+
+    try {
+      const raw = window.sessionStorage?.getItem(storageKey);
+      if (!raw) return null;
+
+      const parsed = JSON.parse(raw);
+      const cachedName = String(parsed?.name || "").trim();
+      const expiresAt = Number(parsed?.expiresAt || 0);
+      if (!cachedName || !Number.isFinite(expiresAt) || expiresAt <= now) {
+        window.sessionStorage?.removeItem(storageKey);
+        return null;
+      }
+
+      orgNameMemoryCache.set(normalizedOrgId, { name: cachedName, expiresAt });
+      return cachedName;
+    } catch (_error) {
+      return null;
+    }
+  }
+
+  /**
+   * Stores organization-name cache entry in memory and session storage.
+   * Purpose: Persist successful org-name lookups for current tab lifecycle.
+   * Necessity: Avoid duplicate network requests for frequently used org IDs.
+   */
+  function setCachedOrganizationName(orgId, name) {
+    const normalizedOrgId = normalizeOrgIdForCache(orgId);
+    const normalizedName = String(name || "").trim();
+    if (!normalizedOrgId || !normalizedName) return;
+
+    const expiresAt = Date.now() + ORG_NAME_CACHE_TTL_MS;
+    orgNameMemoryCache.set(normalizedOrgId, { name: normalizedName, expiresAt });
+
+    const storageKey = getOrgNameCacheStorageKey(normalizedOrgId);
+    if (!storageKey) return;
+
+    try {
+      window.sessionStorage?.setItem(
+        storageKey,
+        JSON.stringify({ name: normalizedName, expiresAt }),
+      );
+    } catch (_error) {
+      // sessionStorage may be unavailable; memory cache still provides benefit.
+    }
+  }
 
   /**
    * Retrieves the set of disabled module IDs from localStorage.
@@ -867,14 +959,22 @@
    * Returns null on network error or missing data (graceful degradation).
    */
   async function getOrganizationName(orgId) {
-    if (!orgId) return null;
+    const normalizedOrgId = normalizeOrgIdForCache(orgId);
+    if (!normalizedOrgId) return null;
+
+    const cached = getCachedOrganizationName(normalizedOrgId);
+    if (cached) return cached;
 
     try {
-      const response = await fetch(`https://www.peeringdb.com/api/org/${orgId}`);
+      const response = await fetch(`https://www.peeringdb.com/api/org/${normalizedOrgId}`);
       if (!response.ok) return null;
 
       const payload = await response.json();
-      return payload?.data?.[0]?.name || null;
+      const resolved = String(payload?.data?.[0]?.name || "").trim();
+      if (!resolved) return null;
+
+      setCachedOrganizationName(normalizedOrgId, resolved);
+      return resolved;
     } catch (_error) {
       return null;
     }

--- a/user.js/peeringdb-cp-consolidated-tools.user.js
+++ b/user.js/peeringdb-cp-consolidated-tools.user.js
@@ -25,6 +25,7 @@
   "use strict";
 
   const MODULE_PREFIX = "pdbCpConsolidated";
+  const SCRIPT_VERSION = "1.0.50.20260323";
   const DUMMY_ORG_ID = 20525;
   const DISABLED_MODULES_STORAGE_KEY = `${MODULE_PREFIX}.disabledModules`;
   const USER_AGENT_STORAGE_KEY = `${MODULE_PREFIX}.userAgent`;
@@ -2713,6 +2714,7 @@
     }
 
     runSelfCheck(ctx);
+    dbg("init", `v${SCRIPT_VERSION}`, { entity: ctx.entity, entityId: ctx.entityId });
     cleanupLegacyPrimaryActionRow();
     dispatchModules(ctx);
     enforceToolbarButtonOrder(ctx);

--- a/user.js/peeringdb-cp-consolidated-tools.user.js
+++ b/user.js/peeringdb-cp-consolidated-tools.user.js
@@ -2711,17 +2711,25 @@
         try {
           const statusPayload = await pdbFetch(`https://www.peeringdb.com/api/ix/${ctx.entityId}`);
           const ixData = statusPayload?.data?.[0];
-          if (!ixData || !ixData.ixf_import_request_status) return;
+          const formIxfStatus = String(
+            getReadonlyFieldValueByLabel("Manual IX-F import status") ||
+            getReadonlyFieldValueByLabel("IX-F import request status") ||
+            getReadonlyFieldValueByLabel("IXF import request status") ||
+            "",
+          ).trim().toLowerCase();
+          const apiIxfStatus = String(ixData?.ixf_import_request_status || "").trim().toLowerCase();
+          const status = formIxfStatus || apiIxfStatus;
+          if (!status) return;
 
-          const status = String(ixData.ixf_import_request_status || "").trim().toLowerCase();
           const statusColors = {
             queued: "#ff9800",
             importing: "#2196f3",
             finished: "#4caf50",
             error: "#f44336",
+            pending: "#ff9800",
           };
           const color = statusColors[status] || "#999";
-          const lastImport = ixData.ixf_last_import ? new Date(ixData.ixf_last_import).toLocaleDateString() : "never";
+          const lastImport = ixData?.ixf_last_import ? new Date(ixData.ixf_last_import).toLocaleDateString() : "never";
 
           const badge = document.createElement("span");
           badge.style.cssText = `

--- a/user.js/peeringdb-cp-consolidated-tools.user.js
+++ b/user.js/peeringdb-cp-consolidated-tools.user.js
@@ -2164,7 +2164,7 @@
 
     const socialMedia = qs("textarea#id_social_media", formArea);
     if (socialMedia) {
-      socialMedia.value = "{}";
+      socialMedia.value = "[]";
     }
 
     eachInForm('input[type="checkbox"]', (item) => {

--- a/user.js/peeringdb-cp-consolidated-tools.user.js
+++ b/user.js/peeringdb-cp-consolidated-tools.user.js
@@ -2614,6 +2614,49 @@
       },
     },
     {
+      id: "network-rir-status-badge",
+      match: (ctx) => ctx.isEntityChangePage && ctx.entity === "network",
+      preconditions: () => Boolean(qs("#grp-content-title")),
+      run: async (ctx) => {
+        try {
+          const statusPayload = await pdbFetch(`https://www.peeringdb.com/api/net/${ctx.entityId}`);
+          const netData = statusPayload?.data?.[0];
+          if (!netData || !netData.rir_status) return;
+
+          const status = String(netData.rir_status || "").trim().toLowerCase();
+          const statusColors = {
+            ok: "#4caf50",
+            invalid: "#f44336",
+            na: "#999",
+          };
+          const color = statusColors[status] || "#999";
+          const updated = netData.rir_status_updated ? new Date(netData.rir_status_updated).toLocaleDateString() : "unknown";
+
+          const badge = document.createElement("span");
+          badge.style.cssText = `
+            display: inline-block;
+            padding: 2px 8px;
+            margin-left: 10px;
+            background-color: ${color};
+            color: white;
+            border-radius: 3px;
+            font-size: 12px;
+            font-weight: bold;
+            white-space: nowrap;
+          `;
+          badge.textContent = `RIR: ${status}`;
+          badge.title = `RIR status: ${status}\nLast updated: ${updated}`;
+
+          const titleArea = qs("#grp-content-title h1") || qs("#grp-content-title");
+          if (titleArea) {
+            titleArea.appendChild(badge);
+          }
+        } catch (_error) {
+          // Gracefully ignore API errors for status badge
+        }
+      },
+    },
+    {
       id: "set-window-title",
       match: (ctx) => ctx.isCp && ctx.isEntityChangePage,
       run: (ctx) => {

--- a/user.js/peeringdb-cp-consolidated-tools.user.js
+++ b/user.js/peeringdb-cp-consolidated-tools.user.js
@@ -1010,6 +1010,35 @@
     return labelByEntity[entity] || "Copy URL";
   }
 
+  /**
+   * Returns human-friendly website label for the current object type.
+   * Purpose: Keep header website action labels concise and entity-specific.
+   * Necessity: Replaces generic "ObjType Website" text with context-aware naming.
+   */
+  function getEntityWebsiteLabel(entity) {
+    const websiteLabelByEntity = {
+      internetexchange: "IX Website",
+      network: "Network Website",
+      facility: "Facility Website",
+      organization: "Org Website",
+      carrier: "Carrier Website",
+      campus: "Campus Website",
+    };
+
+    if (websiteLabelByEntity[entity]) {
+      return websiteLabelByEntity[entity];
+    }
+
+    const fallback = String(entity || "")
+      .trim()
+      .replace(/[_-]+/g, " ")
+      .replace(/\s+/g, " ")
+      .toLowerCase()
+      .replace(/\b\w/g, (char) => char.toUpperCase());
+
+    return `${fallback || "Entity"} Website`;
+  }
+
   function getOrganizationIdForNameUpdate(ctx) {
     if (!ctx?.isEntityChangePage) return "";
     if (ctx.entity === "organization") return String(ctx.entityId || "").trim();
@@ -2498,7 +2527,7 @@
         if (/^https?:\/\//i.test(objTypeWebsiteUrl)) {
           addToolbarAction({
             id: `${MODULE_PREFIX}ObjTypeWebsite`,
-            label: "ObjType Website",
+            label: getEntityWebsiteLabel(ctx.entity),
             href: objTypeWebsiteUrl,
             target: `pdb_${grainyIdentity}_objtype_website`,
             insertLeft: true,
@@ -2509,7 +2538,7 @@
         if (/^https?:\/\//i.test(objOrgWebsiteUrl)) {
           addToolbarAction({
             id: `${MODULE_PREFIX}ObjOrgWebsite`,
-            label: "ObjOrg Website",
+            label: "Org Website",
             href: objOrgWebsiteUrl,
             target: `pdb_${grainyIdentity}_objorg_website`,
             insertLeft: true,

--- a/user.js/peeringdb-cp-consolidated-tools.user.js
+++ b/user.js/peeringdb-cp-consolidated-tools.user.js
@@ -8,6 +8,7 @@
 // @icon         https://icons.duckduckgo.com/ip2/peeringdb.com.ico
 // @grant        GM_xmlhttpRequest
 // @grant        GM_notification
+// @grant        GM_registerMenuCommand
 // @run-at       document-end
 // @connect      data.iana.org
 // @connect      rdap.arin.net
@@ -2100,6 +2101,35 @@
    * Purpose: Parse route, dispatch modules, and enforce button order on current page.
    * Necessity: Single entry point for all initialization logic; ensures modules run before layout.
    */
+  let cpMenuCommandsRegistered = false;
+
+  /**
+   * Registers one-time Tampermonkey menu commands for common CP actions.
+   * Purpose: Provide keyboard/popup access to frequent actions without toolbar clicks.
+   * Necessity: Power users benefit from script actions in the Tampermonkey command menu.
+   */
+  function registerCpMenuCommands() {
+    if (cpMenuCommandsRegistered) return;
+    if (typeof GM_registerMenuCommand !== "function") return;
+    cpMenuCommandsRegistered = true;
+
+    GM_registerMenuCommand("CP: Update Name", () => {
+      qs(`#${MODULE_PREFIX}UpdateEntityName`)?.click();
+    });
+
+    GM_registerMenuCommand("CP: Copy Entity URL", () => {
+      qs(`#${MODULE_PREFIX}CopyEntityUrl`)?.click();
+    });
+
+    GM_registerMenuCommand("CP: Copy Org URL", () => {
+      qs(`#${MODULE_PREFIX}CopyOrganizationUrl`)?.click();
+    });
+
+    GM_registerMenuCommand("CP: Reset Information", () => {
+      qs(`#${MODULE_PREFIX}ResetNetworkInformation`)?.click();
+    });
+  }
+
   function runConsolidatedInit() {
     const ctx = getRouteContext();
 
@@ -2110,6 +2140,7 @@
     cleanupLegacyPrimaryActionRow();
     dispatchModules(ctx);
     enforceToolbarButtonOrder(ctx);
+    registerCpMenuCommands();
   }
 
   if (document.readyState === "loading") {

--- a/user.js/peeringdb-cp-consolidated-tools.user.js
+++ b/user.js/peeringdb-cp-consolidated-tools.user.js
@@ -3226,6 +3226,30 @@
           if (titleArea) {
             titleArea.appendChild(badge);
           }
+
+          // Append clickable link to IXF member list URL if available.
+          // Purpose: Direct access to the exchange member list without extra navigation.
+          const memberListUrl = String(ixData?.ixf_ixp_member_list_url || "").trim();
+          if (memberListUrl && titleArea) {
+            const linkSpan = document.createElement("span");
+            linkSpan.style.cssText = `
+              display: inline-block;
+              margin-left: 8px;
+            `;
+            const link = document.createElement("a");
+            link.href = memberListUrl;
+            link.target = "_blank";
+            link.rel = "noopener noreferrer";
+            link.textContent = "Members";
+            link.style.cssText = `
+              color: #2196f3;
+              text-decoration: none;
+              font-size: 12px;
+              font-weight: bold;
+            `;
+            linkSpan.appendChild(link);
+            titleArea.appendChild(linkSpan);
+          }
         } catch (_error) {
           // Gracefully ignore API errors for status badge
         }

--- a/user.js/peeringdb-cp-consolidated-tools.user.js
+++ b/user.js/peeringdb-cp-consolidated-tools.user.js
@@ -616,6 +616,36 @@
     return `/${slug}/${ctx.entityId}`;
   }
 
+  /**
+   * Resolves PeeringDB API resource slug for a CP entity type.
+   * Purpose: Build direct JSON API links for the current entity page.
+   * Necessity: CP workflows often require quick access to canonical API payloads.
+   */
+  function getEntityApiResourceByEntity(entity) {
+    const apiResourceByEntity = {
+      facility: "fac",
+      network: "net",
+      organization: "org",
+      carrier: "carrier",
+      internetexchange: "ix",
+      campus: "campus",
+    };
+
+    return apiResourceByEntity[entity] || "";
+  }
+
+  /**
+   * Builds full API JSON URL for the current CP entity context.
+   * Purpose: Provide one-click navigation to the matching API record.
+   * Necessity: Avoid manual URL crafting when validating backend/source-of-truth data.
+   */
+  function getEntityApiJsonUrl(ctx) {
+    const resource = getEntityApiResourceByEntity(ctx?.entity);
+    const entityId = String(ctx?.entityId || "").trim();
+    if (!resource || !entityId) return "";
+    return `https://www.peeringdb.com/api/${resource}/${entityId}`;
+  }
+
   function getEntityCopyLabel(entity) {
     const labelByEntity = {
       facility: "Copy Facility URL",
@@ -1057,6 +1087,7 @@
       reorderChildrenByPriority(secondaryRow, [
         'li[data-pdb-cp-secondary-action="pdbCpConsolidatedUpdateEntityName"]',
         'li[data-pdb-cp-secondary-action="pdbCpConsolidatedMapsDropdown"]',
+        'li[data-pdb-cp-secondary-action="pdbCpConsolidatedCopyEntityId"]',
         'li[data-pdb-cp-secondary-action="pdbCpConsolidatedCopyEntityUrl"]',
         'li[data-pdb-cp-secondary-action="pdbCpConsolidatedCopyOrganizationUrl"]',
       ]);
@@ -1822,6 +1853,27 @@
       match: (ctx) => ctx.isEntityChangePage,
       preconditions: () => Boolean(getToolbarList()),
       run: (ctx) => {
+        addSecondaryActionButton({
+          id: `${MODULE_PREFIX}CopyEntityId`,
+          label: `Copy ID ${ctx.entityId}`,
+          onClick: async (event) => {
+            const copied = await copyToClipboard(String(ctx.entityId || ""));
+            if (copied) {
+              pulseToolbarButton(event?.target, "Copied ID");
+            }
+          },
+        });
+
+        const apiJsonUrl = getEntityApiJsonUrl(ctx);
+        if (apiJsonUrl) {
+          addToolbarAction({
+            id: `${MODULE_PREFIX}ApiJson`,
+            label: "API JSON",
+            href: apiJsonUrl,
+            target: "_new",
+          });
+        }
+
         const entityPath = getEntityFrontendPath(ctx);
         if (entityPath) {
           addSecondaryActionButton({

--- a/user.js/peeringdb-cp-consolidated-tools.user.js
+++ b/user.js/peeringdb-cp-consolidated-tools.user.js
@@ -29,6 +29,7 @@
   const DISABLED_MODULES_STORAGE_KEY = `${MODULE_PREFIX}.disabledModules`;
   const USER_AGENT_STORAGE_KEY = `${MODULE_PREFIX}.userAgent`;
   const SESSION_UUID_STORAGE_KEY = `${MODULE_PREFIX}.sessionUuid`;
+  const DIAGNOSTICS_STORAGE_KEY = `${MODULE_PREFIX}.debug`;
   const TRUSTED_DOMAINS_FOR_UA = [
     "peeringdb.com",
     "*.peeringdb.com",
@@ -373,6 +374,30 @@
     const normalizedKey = String(lockKey || "").trim();
     if (!normalizedKey) return;
     activeActionLocks.delete(normalizedKey);
+  }
+
+  /**
+   * Returns true when diagnostics/debug mode is enabled via localStorage.
+   * Purpose: Gate verbose console output behind an opt-in flag so normal
+   * production use is silent.
+   * Toggle with: localStorage.setItem('pdbCpConsolidated.debug', '1')
+   *   or via the Tampermonkey menu command "CP: Toggle Debug Mode".
+   */
+  function isDebugEnabled() {
+    return window.localStorage?.getItem(DIAGNOSTICS_STORAGE_KEY) === "1";
+  }
+
+  /**
+   * Structured debug logger — no-ops unless debug mode is active.
+   * Purpose: Provide consistent prefixed console output for module and
+   * bus diagnostics without polluting normal page console output.
+   * @param {string} tag  - short subsystem label shown in brackets.
+   * @param {string} msg  - human-readable message.
+   * @param {...*}   rest - optional extra values forwarded to console.debug.
+   */
+  function dbg(tag, msg, ...rest) {
+    if (!isDebugEnabled()) return;
+    console.debug(`[${MODULE_PREFIX}:${tag}]`, msg, ...rest);
   }
 
   /**
@@ -2531,22 +2556,35 @@
    */
   function dispatchModules(ctx) {
     const disabledModules = getDisabledModules();
+    dbg("dispatch", "running", { entity: ctx.entity, entityId: ctx.entityId });
 
     modules.forEach((module) => {
       try {
-        if (!isModuleEnabled(module.id, disabledModules)) return;
-        if (!module.match(ctx)) return;
-        if (typeof module.preconditions === "function" && !module.preconditions(ctx)) return;
+        if (!isModuleEnabled(module.id, disabledModules)) {
+          dbg("dispatch", `skip (disabled) ${module.id}`);
+          return;
+        }
+        if (!module.match(ctx)) {
+          dbg("dispatch", `skip (no match) ${module.id}`);
+          return;
+        }
+        if (typeof module.preconditions === "function" && !module.preconditions(ctx)) {
+          dbg("dispatch", `skip (preconditions) ${module.id}`);
+          return;
+        }
 
         const existingDispose = moduleDisposers.get(module.id);
         if (typeof existingDispose === "function") {
+          dbg("dispatch", `dispose ${module.id}`);
           try { existingDispose(); } catch (_err) { /* ignore dispose errors */ }
           moduleDisposers.delete(module.id);
         }
 
+        dbg("dispatch", `run ${module.id}`);
         const result = module.run(ctx);
         if (typeof result === "function") {
           moduleDisposers.set(module.id, result);
+          dbg("dispatch", `disposer stored ${module.id}`);
         }
       } catch (error) {
         console.warn(`[${MODULE_PREFIX}] module failed: ${module.id}`, error);
@@ -2600,6 +2638,19 @@
       notifyUser({
         title: "PeeringDB CP",
         text: "RDAP caches cleared.",
+      });
+    });
+
+    GM_registerMenuCommand("CP: Toggle Debug Mode", () => {
+      const next = isDebugEnabled() ? null : "1";
+      if (next) {
+        window.localStorage?.setItem(DIAGNOSTICS_STORAGE_KEY, next);
+      } else {
+        window.localStorage?.removeItem(DIAGNOSTICS_STORAGE_KEY);
+      }
+      notifyUser({
+        title: "PeeringDB CP",
+        text: `Debug mode ${next ? "enabled" : "disabled"}.`,
       });
     });
   }

--- a/user.js/peeringdb-cp-consolidated-tools.user.js
+++ b/user.js/peeringdb-cp-consolidated-tools.user.js
@@ -244,6 +244,7 @@
    * 3) deleted (all entities)
    * Purpose: Align visual background behavior with policy-defined ordering.
    * Necessity: Inline per-module background changes can conflict and obscure precedence.
+   * @param {{ entity: string, status: string, isDummyChildFacility: boolean }} ctx - Route context.
    */
   function applyEntityStateBackgroundClass(ctx) {
     const bgContainer = qs("#grp-content");
@@ -272,6 +273,7 @@
    * Synchronizes title markers for dummy-facility and deleted states.
    * Purpose: Keep heading markers accurate as admins edit status/org fields in-place.
    * Necessity: Marker rendering previously relied on module-local one-time insertions.
+   * @param {{ entity: string }} ctx - Route context used to resolve the current visual state.
    */
   function syncEntityStateTitleMarkers(ctx) {
     const title = qs("#grp-content-title h1");
@@ -331,6 +333,8 @@
    * Purpose: Refresh state highlighting when admins change status or org while editing.
    * Necessity: Without listeners, styling only reflects the state at initial page load.
    * Returns a dispose function that unsubscribes from the bus (lifecycle support).
+   * @param {{ entity: string }} ctx - Route context passed through to refresh callbacks.
+   * @returns {Function|null} Dispose function that removes bus subscriptions, or null.
    */
   function bindEntityStateBackgroundReactivity(ctx) {
     const statusSelect = qs("#id_status");
@@ -358,6 +362,7 @@
    * Closes a single dropdown action item and resets its toggle accessibility state.
    * Purpose: Provide centralized close behavior for toolbar and secondary-row dropdowns.
    * Necessity: Shared close logic prevents duplicated listener code per dropdown instance.
+   * @param {HTMLLIElement} listItem - The dropdown list item to close.
    */
   function closeDropdownActionItem(listItem) {
     if (!listItem) return;
@@ -381,6 +386,7 @@
    * Closes all open dropdowns except an optional exempt item.
    * Purpose: Enforce single-open-dropdown behavior across custom CP action menus.
    * Necessity: Simplifies global click/escape handling and keeps UI predictable.
+   * @param {HTMLLIElement|null} [exemptItem=null] - Optional item to leave open.
    */
   function closeAllDropdownActionItems(exemptItem = null) {
     Array.from(openDropdownActionItems).forEach((listItem) => {
@@ -419,6 +425,8 @@
    * Attempts to acquire a named action lock.
    * Purpose: Prevent duplicate execution for long-running script-driven actions.
    * Necessity: Double clicks or repeated menu triggers can race and produce duplicate saves.
+   * @param {string} lockKey - Unique identifier for the action being locked.
+   * @returns {boolean} True when the lock was acquired; false if already held.
    */
   function tryBeginActionLock(lockKey) {
     const normalizedKey = String(lockKey || "").trim();
@@ -433,6 +441,7 @@
    * Releases a previously acquired action lock.
    * Purpose: Re-enable action execution after async work completes.
    * Necessity: Locks must always be released to avoid permanent action blocking.
+   * @param {string} lockKey - Unique identifier for the lock to release.
    */
   function endActionLock(lockKey) {
     const normalizedKey = String(lockKey || "").trim();
@@ -446,6 +455,7 @@
    * production use is silent.
    * Toggle with: localStorage.setItem('pdbCpConsolidated.debug', '1')
    *   or via the Tampermonkey menu command "CP: Toggle Debug Mode".
+   * @returns {boolean} True when debug mode is active.
    */
   function isDebugEnabled() {
     return window.localStorage?.getItem(DIAGNOSTICS_STORAGE_KEY) === "1";
@@ -468,6 +478,8 @@
    * Normalizes organization ID into a stable cache key suffix.
    * Purpose: Ensure cache keys are deterministic across string/number ID inputs.
    * Necessity: Different call sites may pass IDs with whitespace or mixed types.
+   * @param {string|number} orgId - Raw organization ID from form field or API response.
+   * @returns {string} Trimmed string representation of the org ID.
    */
   function normalizeOrgIdForCache(orgId) {
     return String(orgId || "").trim();
@@ -477,6 +489,8 @@
    * Builds sessionStorage key used for persisted org-name cache entries.
    * Purpose: Keep all org-name cache keys namespaced under module prefix.
    * Necessity: Avoid collisions with other userscripts and local app storage keys.
+   * @param {string|number} orgId - Organization ID to build the key for.
+   * @returns {string} Namespaced sessionStorage key, or empty string if orgId is invalid.
    */
   function getOrgNameCacheStorageKey(orgId) {
     const normalizedOrgId = normalizeOrgIdForCache(orgId);
@@ -489,6 +503,8 @@
    * Purpose: Reuse recent org-name lookups to reduce repeated API requests.
    * Necessity: Update Name and Reset Information may request the same org repeatedly.
    * Returns null when cache is absent, malformed, or expired.
+   * @param {string|number} orgId - Organization ID to look up.
+   * @returns {string|null} Cached organization name, or null on miss/expiry/malform.
    */
   function getCachedOrganizationName(orgId) {
     const normalizedOrgId = normalizeOrgIdForCache(orgId);
@@ -537,6 +553,8 @@
    * Stores organization-name cache entry in memory and session storage.
    * Purpose: Persist successful org-name lookups for current tab lifecycle.
    * Necessity: Avoid duplicate network requests for frequently used org IDs.
+   * @param {string|number} orgId - Organization ID to cache the name for.
+   * @param {string} name - Resolved organization name to persist.
    */
   function setCachedOrganizationName(orgId, name) {
     const normalizedOrgId = normalizeOrgIdForCache(orgId);
@@ -592,6 +610,7 @@
    * Purpose: Allows individual modules to be toggled on/off without code changes.
    * Necessity: Provides user-level module control for the modular architecture.
    * Supports both JSON array and comma-separated formats for backward compatibility.
+   * @returns {Set<string>} Set of module ID strings that are currently disabled.
    */
   function getDisabledModules() {
     const raw = String(window.localStorage?.getItem(DISABLED_MODULES_STORAGE_KEY) || "").trim();
@@ -618,6 +637,9 @@
    * Checks if a module is enabled (not in the disabled set).
    * Purpose: Gate-keeper for module execution in dispatchModules().
    * Necessity: Implements selective module control without removing code.
+   * @param {string} moduleId - The module identifier to check.
+   * @param {Set<string>} disabledModules - Set of currently disabled module IDs.
+   * @returns {boolean} True when the module is enabled (not in the disabled set).
    */
   function isModuleEnabled(moduleId, disabledModules) {
     if (!moduleId) return false;
@@ -628,6 +650,7 @@
    * Retrieves explicit or auto-computed User-Agent for this session.
    * Purpose: Provide flexible UA configuration with fallback to trust-based generation.
    * Necessity: Allows manual override via localStorage while auto-computing from domain trust.
+   * @returns {string} User-Agent string to use for outgoing requests.
    */
   function getCustomRequestUserAgent() {
     const configured = String(window.localStorage?.getItem(USER_AGENT_STORAGE_KEY) || "").trim();
@@ -641,6 +664,7 @@
    * Purpose: Provides a unique identifier for correlating requests within a session.
    * Necessity: Enables server-side analytics and request tracking without exposing device fingerprint.
    * UUID persists across page reloads but is cleared when tab/session closes.
+   * @returns {string} Session UUID string (generated once per browser session).
    */
   function getSessionUuid() {
     const sessionKey = SESSION_UUID_STORAGE_KEY;
@@ -659,6 +683,7 @@
    * Purpose: Creates a privacy-preserving identifier for requests from untrusted domains.
    * Necessity: Balances analytics tracking with user privacy for non-trusted networks.
    * Returns a 16-character hex string derived from UA, platform, language, CPU count, memory.
+   * @returns {string} 16-character lowercase hex fingerprint string.
    */
   function computeClientFingerprint() {
     const parts = [
@@ -684,6 +709,8 @@
    * Necessity: Distinguishes between trusted (localhost, peeringdb.com) and untrusted domains
    * to decide whether to use full browser info or privacy-preserving fingerprint.
    * Also normalizes IPv6 URIs with bracket notation ([::1]) for transparent matching.
+   * @param {string} domain - Hostname to test (e.g., "www.peeringdb.com", "localhost").
+   * @returns {boolean} True when the domain matches a TRUSTED_DOMAINS_FOR_UA entry.
    */
   function isDomainTrusted(domain) {
     if (!domain) return false;
@@ -715,6 +742,8 @@
    * Necessity: For trusted domains (development, peeringdb.com), includes browser/platform for debugging;
    * for untrusted domains, uses fingerprint only to minimize data exposure.
    * Includes session UUID in both cases for request correlation.
+   * @param {string} domain - Hostname of the page making the request.
+   * @returns {string} Constructed User-Agent header value.
    */
   function buildTrustBasedUserAgent(domain) {
     const isTrusted = isDomainTrusted(domain);
@@ -735,6 +764,8 @@
    * Constructs HTTP headers for Tampermonkey requests with User-Agent.
    * Purpose: Centralize header building for all script-initiated requests.
    * Necessity: Ensures consistent User-Agent and other important headers across all API calls.
+   * @param {object} [baseHeaders={}] - Optional base headers to merge with generated ones.
+   * @returns {object} Header object with User-Agent key populated.
    */
   function buildTampermonkeyRequestHeaders(baseHeaders = {}) {
     const headers = { ...baseHeaders };
@@ -751,6 +782,15 @@
     return headers;
   }
 
+  /**
+   * Parses the current window URL into a structured CP route context object.
+   * Purpose: Provide a single authoritative source of routing data for all modules.
+   * Necessity: Multiple modules need entity type, entity ID, and page kind without
+   * re-parsing the URL each time — centralizing parsing prevents divergent path logic.
+   * @returns {{ host: string, path: string[], pathName: string, isCp: boolean,
+   *             entity: string, entityId: string, pageKind: string,
+   *             isEntityChangePage: boolean }}
+   */
   function getRouteContext() {
     const path = window.location.pathname.replace(/(^\/|\/$)/g, "").split("/");
     return {
@@ -773,6 +813,8 @@
    * Necessity: Reactive listeners can fire dozens of times per second; batching keeps
    * visual updates smooth without debounce latency.
    * If a callback is already pending for the same key, the new fn replaces it.
+   * @param {string} key - Deduplication key; one pending callback allowed per key.
+   * @param {Function} fn - DOM write callback to execute in the next animation frame.
    */
   function scheduleDomUpdate(key, fn) {
     if (pendingDomUpdates.has(key)) {
@@ -843,6 +885,9 @@
    * Purpose: Reduce boilerplate for DOM querying throughout the script.
    * Necessity: Used extensively for finding form fields and toolbar elements.
    * Wraps in try-catch to safely return null on selector errors.
+   * @param {string} selector - CSS selector string.
+   * @param {Document|Element} [root=document] - Optional scoping root element.
+   * @returns {Element|null} First matching element, or null.
    */
   function qs(selector, root = document) {
     try {
@@ -856,6 +901,9 @@
    * Convenience wrapper for querySelectorAll returning an array.
    * Purpose: Reduce boilerplate for finding multiple DOM elements.
    * Necessity: Used for inline sets, dynamic forms, and multi-element operations.
+   * @param {string} selector - CSS selector string.
+   * @param {Document|Element} [root=document] - Optional scoping root element.
+   * @returns {Element[]} Array of matching elements (may be empty).
    */
   function qsa(selector, root = document) {
     try {
@@ -869,6 +917,8 @@
    * Retrieves trimmed value from form input elements (input, select, textarea).
    * Purpose: Unified value extraction that handles both .value property and data attributes.
    * Necessity: Normalizes form field reading across different input types in Django admin forms.
+   * @param {string} selector - CSS selector for the target input element.
+   * @returns {string} Trimmed value string, or empty string if element not found.
    */
   function getInputValue(selector) {
     const element = qs(selector);
@@ -881,6 +931,14 @@
     return String(element.getAttribute("value") || "").trim();
   }
 
+  /**
+   * Reads the visible text of the currently selected option from a `<select>` element.
+   * Purpose: Unified selected-option reader that works across choice and render states.
+   * Necessity: `option:checked` and `option[selected]` behave differently across browsers
+   * and scripted form states; normalizing prevents silent empty reads.
+   * @param {string} selector - CSS selector for the target `<select>` element.
+   * @returns {string} Trimmed text of the selected option, or empty string if absent.
+   */
   function getSelectedOptionText(selector) {
     const select = qs(selector);
     if (!select) return "";
@@ -894,6 +952,14 @@
     return String(selectedOption?.textContent || "").trim();
   }
 
+  /**
+   * Builds a geocoding query string for facility address map links.
+   * Purpose: Prefer lat/long coordinates when available for precise map links,
+   * falling back to a formatted street address when coordinates are absent.
+   * Necessity: Facilities may have coordinates or address-only data; a unified
+   * builder covers both cases without branching at the call site.
+   * @returns {string} Comma-separated coordinate pair or formatted address string.
+   */
   function buildFacilityMapsQuerySource() {
     const latitude = getInputValue("#id_latitude");
     const longitude = getInputValue("#id_longitude");
@@ -919,6 +985,9 @@
    * Sets value on form input elements with consistent synchronization.
    * Purpose: Unified value assignment that updates both .value and attributes.
    * Necessity: Ensures form frameworks recognize the change (defaultValue for reset detection).
+   * @param {string} selector - CSS selector for the target input element.
+   * @param {string} value - Value to assign to the matched element.
+   * @returns {boolean} True when the element was found and updated; false otherwise.
    */
   function setInputValue(selector, value) {
     const element = qs(selector);
@@ -940,6 +1009,8 @@
    * Sets network name field value with proper change event firing.
    * Purpose: Ensure form validation and dependency updates trigger when name changes.
    * Necessity: Django admin forms monitor change events; manual setting requires event dispatch.
+   * @param {string} value - New name value to assign to the network name input.
+   * @returns {boolean} True when the #id_name element was found and updated.
    */
   function setNetworkNameValue(value) {
     const input = document.getElementById("id_name");
@@ -959,6 +1030,10 @@
    * Purpose: Provide sensible fallback names for networks when org lookup fails.
    * Necessity: Required field can't be empty; ASN is stable and visible on network pages.
    * Includes '#deleted' suffix for networks in deleted status.
+   * @param {string|number} asn - Autonomous System Number (with or without "AS" prefix).
+   * @param {string|number} networkId - CP network record ID used as fallback.
+   * @param {string} [suffix=""] - Optional suffix to append (e.g., " #42" for deleted records).
+   * @returns {string} Generated fallback name string (e.g., "AS64496 #42").
    */
   function getDeterministicNetworkFallbackName(asn, networkId, suffix = "") {
     const cleaned = String(asn || "").replace(/^AS/i, "").trim();
@@ -970,10 +1045,25 @@
     return `AS${networkId}${suffix}`;
   }
 
+  /**
+   * Returns the PeeringDB frontend URL slug for a given CP entity type.
+   * Purpose: Translate internal CP entity names to their public frontend URL segments.
+   * Necessity: Centralizes the entity→slug mapping shared by frontend links and API paths.
+   * @param {string} entity - Lowercase CP entity type (e.g., "internetexchange").
+   * @returns {string} Frontend URL slug (e.g., "ix"), or empty string if unmapped.
+   */
   function getFrontendSlugByEntity(entity) {
     return ENTITY_SLUG_MAP[entity] || "";
   }
 
+  /**
+   * Builds the root-relative frontend URL path for the current entity context.
+   * Purpose: Generate the canonical frontend path used for toolbar link href values.
+   * Necessity: Centralizes path construction from entity type + ID to avoid slug/ID drift
+   * across separate call sites that build frontend links.
+   * @param {{ entity: string, entityId: string }} ctx - Route context from getRouteContext().
+   * @returns {string} Root-relative path such as "/ix/42", or empty string on failure.
+   */
   function getEntityFrontendPath(ctx) {
     const slug = getFrontendSlugByEntity(ctx?.entity);
     if (!slug || !ctx?.entityId) return "";
@@ -984,6 +1074,8 @@
    * Resolves PeeringDB API resource slug for a CP entity type.
    * Purpose: Build direct JSON API links for the current entity page.
    * Necessity: CP workflows often require quick access to canonical API payloads.
+   * @param {string} entity - Lowercase CP entity type (e.g., "internetexchange").
+   * @returns {string} API resource slug (e.g., "ix"), or empty string if unmapped.
    */
   function getEntityApiResourceByEntity(entity) {
     return ENTITY_API_RESOURCE_MAP[entity] || "";
@@ -993,6 +1085,8 @@
    * Builds full API JSON URL for the current CP entity context.
    * Purpose: Provide one-click navigation to the matching API record.
    * Necessity: Avoid manual URL crafting when validating backend/source-of-truth data.
+   * @param {{ entity: string, entityId: string }} ctx - Route context from getRouteContext().
+   * @returns {string} Full API URL (e.g., "https://www.peeringdb.com/api/ix/42"), or empty string.
    */
   function getEntityApiJsonUrl(ctx) {
     const resource = getEntityApiResourceByEntity(ctx?.entity);
@@ -1005,6 +1099,9 @@
    * Builds a canonical PeeringDB API object URL for resource/id pairs.
    * Purpose: Keep API endpoint construction centralized and consistent.
    * Necessity: Avoids hardcoded URL drift across modules.
+   * @param {string} resource - API resource slug (e.g., "org", "ix").
+   * @param {string|number} entityId - Entity record ID.
+   * @returns {string} Full API URL, or empty string if either argument is invalid.
    */
   function getPeeringDbApiObjectUrl(resource, entityId) {
     const normalizedResource = String(resource || "").trim();
@@ -1014,9 +1111,12 @@
   }
 
   /**
-   * Safely returns the first object in PeeringDB list responses.
-   * Purpose: Standardize extraction of the first `data` row from API payloads.
-   * Necessity: Reduces repeated optional-chaining logic and malformed-shape edge cases.
+   * Emits a one-time console warning for malformed or unexpected API payload shapes.
+   * Purpose: Surface API contract violations in debug mode without flooding the console.
+   * Necessity: The same endpoint can be called many times per session; deduplication
+   * via a Set ensures the warning fires only once per source URL.
+   * @param {string} source - Endpoint URL or identifier where the payload was received.
+   * @param {*} payload - The malformed payload value forwarded to console.warn.
    */
   function warnMalformedApiPayloadOnce(source, payload) {
     if (!isDebugEnabled()) return;
@@ -1028,6 +1128,15 @@
     console.warn(`[${MODULE_PREFIX}] Unexpected API payload shape at '${warningKey}'`, payload);
   }
 
+  /**
+   * Safely returns the first data row from a PeeringDB list API response.
+   * Purpose: Standardize extraction of the first `data` entry from API payloads.
+   * Necessity: Reduces repeated optional-chaining and handles malformed shapes uniformly
+   * by delegating shape warnings to warnMalformedApiPayloadOnce.
+   * @param {*} payload - Raw JSON response object from a PeeringDB list endpoint.
+   * @param {string} [source="unknown"] - Endpoint URL for diagnostic messages.
+   * @returns {object|null} First item in `payload.data`, or null on any shape mismatch.
+   */
   function getFirstApiDataItem(payload, source = "unknown") {
     if (!payload || typeof payload !== "object") {
       warnMalformedApiPayloadOnce(source, payload);
@@ -1047,6 +1156,8 @@
    * Returns a reason code when API JSON action should be blocked.
    * Purpose: Keep visibility and click-policy checks consistent.
    * Necessity: Some entities may not expose status reliably; block only when policy-relevant.
+   * @param {{ entity: string, entityId: string }} ctx - Route context from getRouteContext().
+   * @returns {string} Empty string when allowed; "missing-endpoint" or "status:<value>" otherwise.
    */
   function getApiJsonActionBlockReason(ctx) {
     const apiJsonUrl = getEntityApiJsonUrl(ctx);
@@ -1065,6 +1176,8 @@
    * Determines whether the API JSON action should be visible for current context.
    * Purpose: Avoid showing the button when action policy does not allow opening.
    * Necessity: Prevent no-op UI affordances for non-OK entities.
+   * @param {{ entity: string, entityId: string }} ctx - Route context from getRouteContext().
+   * @returns {boolean} True when the API JSON toolbar action should be shown.
    */
   function shouldShowApiJsonAction(ctx) {
     return !getApiJsonActionBlockReason(ctx);
@@ -1094,6 +1207,14 @@
     dbg("self-check", "api resource coverage ok", { count: mappedResources.length });
   }
 
+  /**
+   * Returns the entity-specific label for the secondary Copy URL action button.
+   * Purpose: Make copy button labels contextually explicit (e.g., "Copy IX URL").
+   * Necessity: A generic "Copy URL" label is ambiguous when Org and Entity
+   * copy buttons both appear on the same secondary action row.
+   * @param {string} entity - Lowercase CP entity type (e.g., "internetexchange").
+   * @returns {string} Human-readable label string for the copy action.
+   */
   function getEntityCopyLabel(entity) {
     const labelByEntity = {
       facility: "Copy Facility URL",
@@ -1111,6 +1232,8 @@
    * Returns human-friendly website label for the current object type.
    * Purpose: Keep header website action labels concise and entity-specific.
    * Necessity: Replaces generic "ObjType Website" text with context-aware naming.
+   * @param {string} entity - Lowercase CP entity type (e.g., "internetexchange").
+   * @returns {string} Human-readable toolbar label (e.g., "IX Website").
    */
   function getEntityWebsiteLabel(entity) {
     const websiteLabelByEntity = {
@@ -1140,6 +1263,8 @@
    * Returns human-friendly frontend label for a CP entity.
    * Purpose: Make the main frontend action explicit about the destination entity type.
    * Necessity: Replaces generic "Frontend" text with entity-specific naming.
+   * @param {string} entity - Lowercase CP entity type (e.g., "internetexchange").
+   * @returns {string} Human-readable label (e.g., "IX (front-end)").
    */
   function getEntityFrontendLabel(entity) {
     const frontendLabelByEntity = {
@@ -1165,12 +1290,28 @@
     return `${fallback || "Entity"} (front-end)`;
   }
 
+  /**
+   * Resolves the organization ID to use when performing an Update Name action.
+   * Purpose: Return the correct org ID source — the entity ID itself for org pages,
+   * or the #id_org field for all other entity types.
+   * Necessity: Organization pages use their own entity ID as the org reference;
+   * child entities (networks, carriers, etc.) need the parent org from the form.
+   * @param {{ isEntityChangePage: boolean, entity: string, entityId: string }} ctx
+   * @returns {string} Organization ID string, or empty string if unresolvable.
+   */
   function getOrganizationIdForNameUpdate(ctx) {
     if (!ctx?.isEntityChangePage) return "";
     if (ctx.entity === "organization") return String(ctx.entityId || "").trim();
     return getInputValue("#id_org");
   }
 
+  /**
+   * Locates and returns the primary CP object-tools toolbar UL element.
+   * Purpose: Provide a single point of access for the main toolbar list.
+   * Necessity: Toolbar selectors differ across Grappelli versions; a unified locator
+   * with multiple fallback selectors avoids duplicate selector logic in every module.
+   * @returns {HTMLUListElement|null} The primary toolbar list element, or null if absent.
+   */
   function getToolbarList() {
     const toolbar = (
       qs("#grp-content-title > ul.grp-object-tools:not([data-pdb-cp-toolbar-row]):not([data-pdb-cp-action])") ||
@@ -1197,6 +1338,7 @@
    * Purpose: Prevent overlap between primary toolbar and secondary action row.
    * Necessity: Secondary row appears below primary toolbar; must account for toolbar height
    * which varies by content. Uses BoundingClientRect to detect actual overlap.
+   * @param {HTMLUListElement} row - The secondary action row element to adjust.
    */
   function applySecondaryRowVerticalOffset(row) {
     if (!row) return;
@@ -1220,6 +1362,9 @@
    * Purpose: Standardized way to add custom buttons (Google Maps, Frontend links, etc.).
    * Necessity: Ensures consistent styling, idempotency (prevents duplicates), and placement.
    * Marks buttons with data-pdb-cp-action attribute for reordering and identification.
+   * @param {{ id: string, label: string, href?: string, onClick?: Function,
+   *           target?: string|null, insertLeft?: boolean }} opts
+   * @returns {HTMLAnchorElement|null} The created anchor element, or null on failure.
    */
   function addToolbarAction({ id, label, href = "#", onClick, target = null, insertLeft = false }) {
     if (!id) return null;
@@ -1293,8 +1438,16 @@
     return a;
   }
 
+  /**
+   * Constructs a reusable dropdown list-item element (toggle anchor + flyout menu).
+   * Purpose: Build the shared DOM structure for multi-item toolbar and secondary-row menus.
+   * Necessity: Both toolbar and secondary-row dropdown helpers use the same toggle/flyout
+   * HTML pattern; centralizing avoids DOM duplication and styling drift.
+   * @param {{ id: string, label: string, items: Array<{label: string, href: string, target?: string}>,
+   *           resolveItemTarget?: Function }} opts
+   * @returns {{ li: HTMLLIElement, toggle: HTMLAnchorElement }|null}
+   */
   function createDropdownActionListItem({ id, label, items, resolveItemTarget = null }) {
-    if (!id || !Array.isArray(items) || items.length === 0) return null;
     ensureDropdownGlobalCloseListener();
 
     const li = document.createElement("li");
@@ -1375,8 +1528,16 @@
     return { li, toggle };
   }
 
+  /**
+   * Creates and inserts a dropdown action button into the primary CP toolbar.
+   * Purpose: Add multi-item expandable menus (e.g., Maps) to the main toolbar UL.
+   * Necessity: Toolbar insertion semantics differ from the secondary row; wrapping
+   * createDropdownActionListItem ensures correct placement and data-pdb-cp-action tagging.
+   * @param {{ id: string, label: string, items: Array<{label: string, href: string}>,
+   *           insertLeft?: boolean }} opts
+   * @returns {HTMLAnchorElement|null} The dropdown toggle anchor element, or null on failure.
+   */
   function addToolbarDropdownAction({ id, label, items, insertLeft = false }) {
-    if (!id || !Array.isArray(items) || items.length === 0) return null;
 
     const existing = qs(`#${id}`);
     if (existing) {
@@ -1426,6 +1587,13 @@
     return toggle;
   }
 
+  /**
+   * Returns the secondary action row UL element, creating and inserting it if absent.
+   * Purpose: Provide a persistent secondary UL row below the primary toolbar for custom buttons.
+   * Necessity: Multiple modules inject secondary buttons; a shared row avoids
+   * multiple disconnected rows and centralizes vertical offset handling.
+   * @returns {HTMLUListElement|null} The secondary action row element, or null on DOM failure.
+   */
   function getOrCreateSecondaryActionRow() {
     const contentTitle = qs("#grp-content-title");
     if (!contentTitle) return null;
@@ -1474,6 +1642,8 @@
    * Creates and appends a button to the secondary action row.
    * Purpose: Add custom actions to secondary row with consistent styling.
    * Necessity: Secondary row actions need inline-block styling and spacing different from primary toolbar.
+   * @param {{ id: string, label: string, href?: string, title?: string, onClick: Function }} opts
+   * @returns {HTMLAnchorElement|null} The created anchor element, or null on failure.
    */
   function addSecondaryActionButton({ id, label, href = "#", title = "", onClick }) {
     const row = getOrCreateSecondaryActionRow();
@@ -1514,6 +1684,14 @@
     return button;
   }
 
+  /**
+   * Creates and appends a dropdown to the secondary action row.
+   * Purpose: Add multi-item expandable actions (e.g., Maps) to the secondary row.
+   * Necessity: Secondary row insertion semantics and item target resolution differ from
+   * the primary toolbar; a dedicated helper keeps module code concise.
+   * @param {{ id: string, label: string, items: Array<{label: string, href: string}> }} opts
+   * @returns {HTMLAnchorElement|null} The dropdown toggle anchor element, or null on failure.
+   */
   function addSecondaryDropdownAction({ id, label, items }) {
     const row = getOrCreateSecondaryActionRow();
     if (!row || !id || !Array.isArray(items) || items.length === 0) return null;
@@ -1535,6 +1713,15 @@
     return toggle;
   }
 
+  /**
+   * Tests whether a container child element matches a priority descriptor.
+   * Purpose: Support both CSS-selector strings and predicate functions in TOOLBAR_*_ORDER arrays.
+   * Necessity: History item uses a function matcher; custom items use CSS attribute selectors;
+   * a unified tester lets one reorder loop handle both types without branching.
+   * @param {Element} child - DOM child element to test.
+   * @param {string|Function} priority - CSS selector string or boolean predicate function.
+   * @returns {boolean} True if `child` matches the given priority descriptor.
+   */
   function isPriorityMatch(child, priority) {
     if (!child || !priority) return false;
 
@@ -1557,6 +1744,8 @@
    * Identifies if a toolbar item is the History button.
    * Purpose: Handle History button specially in reordering (position it before custom actions).
    * Necessity: History button is Django admin native; needs position priority awareness.
+   * @param {Element} child - Toolbar LI element to test.
+   * @returns {boolean} True when the element is the native History button.
    */
   function isHistoryToolbarItem(child) {
     if (!child || child.hasAttribute("data-pdb-cp-action")) return false;
@@ -1574,6 +1763,8 @@
    * Purpose: Establish deterministic button order (Frontend before Org links, History before custom).
    * Necessity: Ensures consistent UI layout across page variations and module load orders.
    * Unmatched children stay in original order at the end.
+   * @param {HTMLElement} container - Parent element whose children will be reordered.
+   * @param {Array<string|Function>} priorities - Ordered list of CSS selectors or predicate functions.
    */
   function reorderChildrenByPriority(container, priorities) {
     if (!container || !Array.isArray(priorities) || priorities.length === 0) return;
@@ -1603,6 +1794,7 @@
    * Purpose: Coordinate reordering of all network page toolbar buttons.
    * Necessity: Network pages have most custom actions; reordering provides consistent UX.
    * For other entity types, no special ordering applied (preserves natural order).
+   * @param {{ isEntityChangePage: boolean, entity: string }} ctx - Route context.
    */
   function enforceToolbarButtonOrder(ctx) {
     if (!ctx?.isEntityChangePage) return;
@@ -1683,6 +1875,9 @@
    * from the entity response instead of making a separate /api/org/{id} call.
    * Necessity: Carrier and Campus schemas include org_name as a readOnly field.
    * Returns null on network error or missing data (graceful degradation).
+   * @param {string} entity - Lowercase CP entity type (e.g., "carrier").
+   * @param {string|number} entityId - CP entity record ID.
+   * @returns {Promise<string|null>} Resolved organization name, or null on failure.
    */
   async function getOrganizationNameFromEntityApi(entity, entityId) {
     const resource = getEntityApiResourceByEntity(entity);
@@ -1707,6 +1902,8 @@
    * Purpose: Resolve human-readable org names for network initialization.
    * Necessity: Network name should match org name; API lookup is more reliable than manual lookup.
    * Returns null on network error or missing data (graceful degradation).
+   * @param {string|number} orgId - PeeringDB organization record ID.
+   * @returns {Promise<string|null>} Resolved organization name, or null on failure.
    */
   async function getOrganizationName(orgId) {
     const normalizedOrgId = normalizeOrgIdForCache(orgId);
@@ -1735,6 +1932,7 @@
    * Programmatically clicks the "Save and continue editing" button.
    * Purpose: Auto-submit form after automated edits (Reset Information, Update Name).
    * Necessity: Script-driven form changes need programmatic submission; improves UX.
+   * @returns {boolean} True when the save button was found and clicked.
    */
   function clickSaveAndContinue() {
     const button =
@@ -1751,6 +1949,10 @@
    * Prompts user to confirm dangerous network reset operation.
    * Purpose: Prevent accidental data loss from Reset Information action.
    * Necessity: Shows user which network is being reset (by ID, ASN, name) for confirmation.
+   * @param {string} asn - ASN string for the network being reset.
+   * @param {string} networkName - Current network name shown in the confirmation prompt.
+   * @param {string|number} networkId - CP network record ID.
+   * @returns {boolean} True when the user confirmed; false when cancelled.
    */
   function confirmDangerousReset(asn, networkName, networkId) {
     const asnLabel = String(asn || "").trim();
@@ -1774,6 +1976,8 @@
    * Copies text to clipboard with modern and fallback implementations.
    * Purpose: Enable "Copy URL" actions for user convenience.
    * Necessity: Handles browsers with and without Clipboard API support.
+   * @param {string} text - Text content to write to the system clipboard.
+   * @returns {Promise<boolean>} Resolves true when copy succeeded; false otherwise.
    */
   async function copyToClipboard(text) {
     const value = String(text || "");
@@ -1808,6 +2012,7 @@
    * Shows a non-blocking userscript notification when supported.
    * Purpose: Surface completion/failure status for long-running CP actions.
    * Necessity: Async updates may complete after several network calls and benefit from toasts.
+   * @param {{ title?: string, text: string, timeout?: number }} opts - Notification options.
    */
   function notifyUser({ title, text, timeout = 2500 }) {
     const normalizedTitle = String(title || "PeeringDB CP").trim();
@@ -1831,6 +2036,8 @@
    * Temporarily changes button text then reverts after a delay.
    * Purpose: Provide user feedback that copy action succeeded.
    * Necessity: "Copied" feedback improves UX for copy-to-clipboard buttons.
+   * @param {HTMLAnchorElement} anchor - The toolbar button anchor whose text will pulse.
+   * @param {string} [successLabel="Copied"] - Temporary label shown during the pulse.
    */
   function pulseToolbarButton(anchor, successLabel = "Copied") {
     if (!anchor) return;
@@ -1846,6 +2053,8 @@
    * Temporarily changes copy-icon button text then reverts after a delay.
    * Purpose: Give immediate feedback for field-level copy actions.
    * Necessity: Field copy buttons are icon-only by default and need success confirmation.
+   * @param {HTMLButtonElement} button - The copy icon button whose text will pulse.
+   * @param {string} [successLabel="Copied"] - Temporary label shown during the pulse.
    */
   function pulseCopyIconButton(button, successLabel = "Copied") {
     if (!button) return;
@@ -1892,6 +2101,8 @@
    * Normalizes text copied from rendered field contents.
    * Purpose: Remove excessive whitespace while preserving readable one-line output.
    * Necessity: Rendered HTML often contains line breaks and spacing artifacts.
+   * @param {string} text - Raw text content extracted from the DOM.
+   * @returns {string} Normalized single-line string with trimmed whitespace.
    */
   function normalizeRenderedCopyText(text) {
     return String(text || "")
@@ -1904,6 +2115,8 @@
    * Finds the field label text for a value container.
    * Purpose: Support field-level filtering rules by human-visible label.
    * Necessity: Some CP rows are metadata or helper rows and should not get copy icons.
+   * @param {HTMLElement} valueCell - The `.c-2` value cell whose parent row label is read.
+   * @returns {string} Lowercase label text, or empty string if no label found.
    */
   function getFieldLabelText(valueCell) {
     const row = valueCell?.closest(".form-row");
@@ -1917,6 +2130,8 @@
    * Resolves best non-help data value from direct controls inside a field value cell.
    * Purpose: Distinguish actual field data from explanatory helper text.
    * Necessity: Prevents copy buttons from appearing when only help text is present.
+   * @param {HTMLElement} valueCell - The `.c-2` value cell to inspect.
+   * @returns {string} Best available data value string, or empty string if none.
    */
   function getDirectFieldDataValue(valueCell) {
     if (!valueCell) return "";
@@ -1966,6 +2181,8 @@
    * Determines whether a value container should receive a copy button.
    * Purpose: Exclude helper/metadata/lookup-only rows while keeping real data fields copiable.
    * Necessity: Avoids noisy icons on rows that do not represent useful copyable values.
+   * @param {HTMLElement} valueCell - The `.c-2` cell to evaluate.
+   * @returns {boolean} True when a copy button should be injected into this cell.
    */
   function shouldAttachCopyButtonToValueCell(valueCell) {
     if (!valueCell) return false;
@@ -1996,6 +2213,8 @@
    * Resolves the best rendered value from a Django admin field value container.
    * Purpose: Prefer human-visible values (grp-readonly, selected option labels) over raw markup.
    * Necessity: Different field types render values differently in CP forms and inline forms.
+   * @param {HTMLElement} container - The `.c-2` or similar value container element.
+   * @returns {string} Best human-visible text value from the container.
    */
   function getRenderedFieldValue(container) {
     if (!container) return "";
@@ -2054,6 +2273,8 @@
    * Determines the frontend URL path for a CP entity (network, carrier, ix).
    * Purpose: Generate correct copy-to-clipboard URL for the current entity type.
    * Necessity: Different entity types map to different URL paths.
+   * @param {{ entity: string, entityId: string }} ctx - Route context from getRouteContext().
+   * @returns {string} Root-relative frontend path (e.g., "/net/42").
    */
   function getCopyNetworkFrontendPath(ctx) {
     if (ctx.entity === "carrier") {
@@ -2071,6 +2292,7 @@
    * Retrieves currently selected status from the status dropdown.
    * Purpose: Determine if network/entity is marked as deleted.
    * Necessity: Used to add " #deleted" suffix to entity names for deleted records.
+   * @returns {string} Lowercase status value (e.g., "ok", "deleted"), or empty string.
    */
   function getSelectedStatus() {
     const statusSelect = qs("#id_status");
@@ -2093,6 +2315,14 @@
     return String(readonlyStatus || "").toLowerCase();
   }
 
+  /**
+   * Returns a `#<entityId>` suffix when the current entity status is "deleted".
+   * Purpose: Append the entity ID to names of deleted records for disambiguation.
+   * Necessity: Deleted entities may share similar names; a stable ID suffix makes
+   * them distinguishable during audits and prevents duplicate-name collisions.
+   * @param {string|number} entityId - The current entity's CP record ID.
+   * @returns {string} ` #<entityId>` when status is "deleted", otherwise empty string.
+   */
   function getNameSuffixForDeletedEntity(entityId) {
     return getSelectedStatus() === "deleted" ? ` #${entityId}` : "";
   }
@@ -2101,6 +2331,8 @@
    * Reads a readonly field value from a form row by its visible label text.
    * Purpose: Prefer values already rendered on the change form over stale API payloads.
    * Necessity: Some readonly values can differ from API fetch timing/state on page load.
+   * @param {string} labelText - Visible row label text (case-insensitive match).
+   * @returns {string} Trimmed text content of the `.grp-readonly` element, or empty string.
    */
   function getReadonlyFieldValueByLabel(labelText) {
     const normalizedLabel = String(labelText || "").trim().toLowerCase();
@@ -2120,6 +2352,8 @@
    * Reads a readonly link href from a form row by its visible label text.
    * Purpose: Reuse row-level links (e.g. Org website) as header actions.
    * Necessity: Some URLs are rendered as readonly anchors rather than inputs.
+   * @param {string} labelText - Visible row label text (case-insensitive match).
+   * @returns {string} href attribute value of the first public link in the row, or empty string.
    */
   function getReadonlyFieldLinkHrefByLabel(labelText) {
     const normalizedLabel = String(labelText || "").trim().toLowerCase();
@@ -2139,6 +2373,8 @@
    * Builds a stable link identity derived from Grainy namespace when available.
    * Purpose: Use deterministic per-object identity in window targets and action semantics.
    * Necessity: Avoid fragile IDs while preserving object-level context in opened links.
+   * @param {{ entity: string, entityId: string }} ctx - Route context from getRouteContext().
+   * @returns {string} Sanitized token derived from Grainy namespace or entity/ID fallback.
    */
   function getGrainyDerivedLinkIdentity(ctx) {
     const grainyNamespace = getReadonlyFieldValueByLabel("Grainy namespace");
@@ -2156,6 +2392,9 @@
    * Normalizes arbitrary text into a deterministic token usable in window target names.
    * Purpose: Guarantee stable, safe target segments for toolbar links.
    * Necessity: Prevents dynamic labels/IDs from creating invalid or inconsistent target names.
+   * @param {string} value - Raw string to normalize into a token.
+   * @param {string} [fallback="item"] - Token to use when value normalizes to empty.
+   * @returns {string} Lowercase alphanumeric-and-underscore token string.
    */
   function toStableIdentityToken(value, fallback = "item") {
     const normalized = String(value || "")
@@ -2171,6 +2410,9 @@
    * Builds deterministic target names for injected primary toolbar links.
    * Purpose: Ensure all nav-header links open in stable, object-scoped tab identities.
    * Necessity: Replaces ad-hoc _new/_blank targets with per-object deterministic targets.
+   * @param {string} actionId - Action identifier string used to compose the target suffix.
+   * @param {{ entity: string, entityId: string }} [ctx] - Route context; defaults to current page.
+   * @returns {string} Stable window target name string (e.g., "pdb_ix_42_pdbCpConsolidatedFrontend").
    */
   function getStableToolbarLinkTarget(actionId, ctx = getRouteContext()) {
     const grainyIdentity = toStableIdentityToken(getGrainyDerivedLinkIdentity(ctx), "entity");
@@ -2539,6 +2781,11 @@
     markDeletedNetworkInlinesForDeletion();
   }
 
+  // ---------------------------------------------------------------------------
+  // Module registry
+  // Each entry declares: id (string), match (ctx predicate), optional preconditions
+  // (ctx predicate), and run (ctx handler that may return a dispose function).
+  // ---------------------------------------------------------------------------
   const modules = [
     {
       id: "copy-frontend-urls",
@@ -3058,6 +3305,7 @@
    * Purpose: Central dispatcher that activates modules for the current page.
    * Necessity: Implements modular architecture; checks both enabled status and page match
    * before running each module. Catches and logs errors to prevent cascade failures.
+   * @param {{ entity: string, entityId: string, isEntityChangePage: boolean }} ctx - Route context.
    */
   function dispatchModules(ctx) {
     const disabledModules = getDisabledModules();
@@ -3169,6 +3417,7 @@
    * a self-check surfaces breakage before a user triggers an action.
    * Always logs to console.warn for any failed check; emits console.debug
    * details in debug mode. Runs at most once per page load.
+   * @param {{ entity: string, entityId: string, pathName: string }} ctx - Route context.
    */
   function runSelfCheck(ctx) {
     runApiResourceCoverageCheck();
@@ -3213,8 +3462,14 @@
     }
   }
 
+  /**
+   * Entry point for the consolidated CP userscript.
+   * Purpose: Orchestrate the full initialization sequence — route context parse,
+   * self-check, legacy cleanup, module dispatch, toolbar ordering, and TM menu registration.
+   * Necessity: A single entry point ensures sequential, predictable initialization
+   * regardless of DOMContentLoaded timing or future module additions.
+   */
   function runConsolidatedInit() {
-    const ctx = getRouteContext();
 
     if (!ctx.isCp || !ctx.isEntityChangePage) {
       return;

--- a/user.js/peeringdb-cp-consolidated-tools.user.js
+++ b/user.js/peeringdb-cp-consolidated-tools.user.js
@@ -3114,21 +3114,22 @@
     if (typeof GM_registerMenuCommand !== "function") return;
     cpMenuCommandsRegistered = true;
 
-    GM_registerMenuCommand("CP: Update Name", () => {
-      qs(`#${MODULE_PREFIX}UpdateEntityName`)?.click();
-    });
+    const registerMenuCommandForButton = (buttonId, fallbackLabel) => {
+      const button = qs(`#${buttonId}`);
+      if (!button) return;
 
-    GM_registerMenuCommand("CP: Copy Entity URL", () => {
-      qs(`#${MODULE_PREFIX}CopyEntityUrl`)?.click();
-    });
+      const label = String(button.textContent || "").trim() || String(fallbackLabel || "").trim();
+      if (!label) return;
 
-    GM_registerMenuCommand("CP: Copy Org URL", () => {
-      qs(`#${MODULE_PREFIX}CopyOrganizationUrl`)?.click();
-    });
+      GM_registerMenuCommand(`CP: ${label}`, () => {
+        qs(`#${buttonId}`)?.click();
+      });
+    };
 
-    GM_registerMenuCommand("CP: Reset Information", () => {
-      qs(`#${MODULE_PREFIX}ResetNetworkInformation`)?.click();
-    });
+    registerMenuCommandForButton(`${MODULE_PREFIX}UpdateEntityName`, "Update Name");
+    registerMenuCommandForButton(`${MODULE_PREFIX}CopyEntityUrl`, "Copy Entity URL");
+    registerMenuCommandForButton(`${MODULE_PREFIX}CopyOrganizationUrl`, "Copy Org URL");
+    registerMenuCommandForButton(`${MODULE_PREFIX}ResetNetworkInformation`, "Reset Information");
 
     GM_registerMenuCommand("CP: Clear Org Name Cache", () => {
       clearOrganizationNameCache();

--- a/user.js/peeringdb-cp-consolidated-tools.user.js
+++ b/user.js/peeringdb-cp-consolidated-tools.user.js
@@ -7,6 +7,7 @@
 // @match        https://www.peeringdb.com/cp/peeringdb_server/*/*/change/*
 // @icon         https://icons.duckduckgo.com/ip2/peeringdb.com.ico
 // @grant        GM_xmlhttpRequest
+// @grant        GM_notification
 // @run-at       document-end
 // @connect      data.iana.org
 // @connect      rdap.arin.net
@@ -1109,6 +1110,29 @@
   }
 
   /**
+   * Shows a non-blocking userscript notification when supported.
+   * Purpose: Surface completion/failure status for long-running CP actions.
+   * Necessity: Async updates may complete after several network calls and benefit from toasts.
+   */
+  function notifyUser({ title, text, timeout = 2500 }) {
+    const normalizedTitle = String(title || "PeeringDB CP").trim();
+    const normalizedText = String(text || "").trim();
+    if (!normalizedText) return;
+
+    try {
+      if (typeof GM_notification === "function") {
+        GM_notification({
+          title: normalizedTitle,
+          text: normalizedText,
+          timeout,
+        });
+      }
+    } catch (_error) {
+      // Notification support may vary per browser/extension environment.
+    }
+  }
+
+  /**
    * Temporarily changes button text then reverts after a delay.
    * Purpose: Provide user feedback that copy action succeeded.
    * Necessity: "Copied" feedback improves UX for copy-to-clipboard buttons.
@@ -1898,7 +1922,13 @@
                 anchor.style.opacity = "";
                 anchor.style.pointerEvents = "";
               }
-              if (!baseName) return;
+              if (!baseName) {
+                notifyUser({
+                  title: "PeeringDB CP",
+                  text: "Update Name: failed to resolve organization name.",
+                });
+                return;
+              }
             }
 
             const nextName = `${baseName}${appendName}`;
@@ -1908,6 +1938,10 @@
             markDeletedNetworkInlinesForDeletion();
             setInputValue("#id_name", nextName);
             clickSaveAndContinue();
+            notifyUser({
+              title: "PeeringDB CP",
+              text: `Update Name: saved '${nextName}'.`,
+            });
           },
         });
       },
@@ -1938,6 +1972,7 @@
             try {
               const orgId = getInputValue("#id_org");
               const appendName = getNameSuffixForDeletedEntity(ctx.entityId);
+              let usedRdapFallback = false;
 
               runNetworkResetActions();
 
@@ -1959,6 +1994,7 @@
                 const rdapOrgName = await rdapAutnumClient.resolveOrganizationNameByAsn(asn);
                 if (rdapOrgName) {
                   setNetworkNameValue(`${rdapOrgName}${appendName}`);
+                  usedRdapFallback = true;
                 }
               }
 
@@ -1969,8 +2005,22 @@
               }
 
               clickSaveAndContinue();
+              notifyUser({
+                title: "PeeringDB CP",
+                text: "Reset Information: changes prepared and save triggered.",
+              });
+              if (usedRdapFallback) {
+                notifyUser({
+                  title: "PeeringDB CP",
+                  text: "Reset Information: RDAP fallback was used for name resolution.",
+                });
+              }
             } catch (error) {
               console.error(`[${MODULE_PREFIX}] Reset failed`, error);
+              notifyUser({
+                title: "PeeringDB CP",
+                text: "Reset Information failed. See console for details.",
+              });
               button.textContent = originalLabel;
               button.style.opacity = "1";
               button.style.pointerEvents = "auto";

--- a/user.js/peeringdb-fp-consolidated-tools.meta.js
+++ b/user.js/peeringdb-fp-consolidated-tools.meta.js
@@ -7,7 +7,8 @@
 // @match        https://www.peeringdb.com/*
 // @exclude      https://www.peeringdb.com/cp/*
 // @icon         https://icons.duckduckgo.com/ip2/peeringdb.com.ico
-// @grant        none
+// @grant        GM_registerMenuCommand
+// @run-at       document-end
 // @updateURL    https://raw.githubusercontent.com/peeringdb/admincom/master/user.js/peeringdb-fp-consolidated-tools.meta.js
 // @downloadURL  https://raw.githubusercontent.com/peeringdb/admincom/master/user.js/peeringdb-fp-consolidated-tools.user.js
 // @supportURL   https://github.com/peeringdb/admincom/issues

--- a/user.js/peeringdb-fp-consolidated-tools.user.js
+++ b/user.js/peeringdb-fp-consolidated-tools.user.js
@@ -8,6 +8,7 @@
 // @exclude      https://www.peeringdb.com/cp/*
 // @icon         https://icons.duckduckgo.com/ip2/peeringdb.com.ico
 // @grant        none
+// @run-at       document-end
 // @updateURL    https://raw.githubusercontent.com/peeringdb/admincom/master/user.js/peeringdb-fp-consolidated-tools.meta.js
 // @downloadURL  https://raw.githubusercontent.com/peeringdb/admincom/master/user.js/peeringdb-fp-consolidated-tools.user.js
 // @supportURL   https://github.com/peeringdb/admincom/issues
@@ -561,6 +562,7 @@
     const copyUrlButton = qs('a[data-pdb-fp-action="copy-url"]', parent);
     const bgpToolsButton = qs('a[data-pdb-fp-action="bgp-tools"]', parent);
     const bgpHeNetButton = qs('a[data-pdb-fp-action="bgp-he-net"]', parent);
+    const copyAsnButton = qs('a[data-pdb-fp-action="copy-asn"]', parent);
     const moreToolsButton = qs('[data-pdb-fp-action="network-tools-overflow"]', parent);
 
     // Route deterministic first-row actions.
@@ -569,7 +571,7 @@
     });
 
     // Route deterministic second-row actions.
-    [bgpToolsButton, bgpHeNetButton, moreToolsButton].forEach((item) => {
+    [bgpToolsButton, bgpHeNetButton, copyAsnButton, moreToolsButton].forEach((item) => {
       if (item) row2.appendChild(item);
     });
 
@@ -677,6 +679,7 @@
       'a[data-pdb-fp-action="copy-url"]',
       'a[data-pdb-fp-action="bgp-tools"]',
       'a[data-pdb-fp-action="bgp-he-net"]',
+      'a[data-pdb-fp-action="copy-asn"]',
       '[data-pdb-fp-action="network-tools-overflow"]',
     ]);
 
@@ -825,6 +828,18 @@
               });
             });
 
+            createTopRightAction({
+              actionId: "copy-asn",
+              label: `Copy AS${asn}`,
+              onClick: (e) => {
+                copyToClipboard(`AS${asn}`);
+                const btn = e.target;
+                const orig = btn.innerText;
+                btn.innerText = "Copied!";
+                setTimeout(() => { btn.innerText = orig; }, 1000);
+              },
+            });
+
             createTopRightOverflowMenu({
               actionId: "network-tools-overflow",
               label: "More Tools",
@@ -835,6 +850,7 @@
                 { label: "IPinfo", url: `https://ipinfo.io/AS${asn}` },
                 { label: "CF Radar", url: `https://radar.cloudflare.com/as${asn}` },
                 { label: "RouteViews", url: "https://routeviews.org/" },
+                { label: "PDB API", url: `https://www.peeringdb.com/api/net/${cpId}` },
               ],
             });
           }

--- a/user.js/peeringdb-fp-consolidated-tools.user.js
+++ b/user.js/peeringdb-fp-consolidated-tools.user.js
@@ -7,7 +7,7 @@
 // @match        https://www.peeringdb.com/*
 // @exclude      https://www.peeringdb.com/cp/*
 // @icon         https://icons.duckduckgo.com/ip2/peeringdb.com.ico
-// @grant        none
+// @grant        GM_registerMenuCommand
 // @run-at       document-end
 // @updateURL    https://raw.githubusercontent.com/peeringdb/admincom/master/user.js/peeringdb-fp-consolidated-tools.meta.js
 // @downloadURL  https://raw.githubusercontent.com/peeringdb/admincom/master/user.js/peeringdb-fp-consolidated-tools.user.js
@@ -1026,6 +1026,35 @@
    * Sets isInitRunning flag to prevent duplicate initialization during mutations.
    */
   let isInitRunning = false;
+  let fpMenuCommandsRegistered = false;
+
+  /**
+   * Registers one-time Tampermonkey menu commands for common FP actions.
+   * Purpose: Provide quick action access via extension menu for frequent workflows.
+   * Necessity: Supports keyboard-driven usage and declutters reliance on toolbar clicks.
+   */
+  function registerFpMenuCommands() {
+    if (fpMenuCommandsRegistered) return;
+    if (typeof GM_registerMenuCommand !== "function") return;
+    fpMenuCommandsRegistered = true;
+
+    GM_registerMenuCommand("FP: Copy URL", () => {
+      qs('a[data-pdb-fp-action="copy-url"]')?.click();
+    });
+
+    GM_registerMenuCommand("FP: Copy AS<N>", () => {
+      qs('a[data-pdb-fp-action="copy-asn"]')?.click();
+    });
+
+    GM_registerMenuCommand("FP: Open Admin Console", () => {
+      const adminLink = qs('a[data-pdb-fp-action="admin-console"]');
+      if (!adminLink) return;
+      const href = String(adminLink.getAttribute("href") || "").trim();
+      if (!href) return;
+      window.open(href, "_blank", "noopener");
+    });
+  }
+
   let consolidatedObserver = null;
   let observerDisconnectTimer = 0;
 
@@ -1112,6 +1141,7 @@
     try {
       dispatchModules(ctx);
       enforceTopRightButtonOrder();
+      registerFpMenuCommands();
     } finally {
       isInitRunning = false;
       scheduleObserverDisconnect();

--- a/user.js/peeringdb-fp-consolidated-tools.user.js
+++ b/user.js/peeringdb-fp-consolidated-tools.user.js
@@ -30,6 +30,7 @@
     "localhost",
   ];
   const DEFAULT_REQUEST_USER_AGENT = "PeeringDB-Admincom-FP-Consolidated";
+  const OBSERVER_IDLE_DISCONNECT_MS = 2000;
 
   /**
    * Retrieves the set of disabled module IDs from localStorage.
@@ -1025,6 +1026,86 @@
    * Sets isInitRunning flag to prevent duplicate initialization during mutations.
    */
   let isInitRunning = false;
+  let consolidatedObserver = null;
+  let observerDisconnectTimer = 0;
+
+  /**
+   * Determines the best DOM root to observe for FP dynamic updates.
+   * Purpose: Minimize observer workload by avoiding full-body observation when possible.
+   * Necessity: Broad body/subtree observation can trigger excessive callbacks on busy pages.
+   */
+  function getObserverRootNode() {
+    return (
+      getTopRightToolbarContainer() ||
+      qs("#content") ||
+      qs("#view") ||
+      document.body
+    );
+  }
+
+  /**
+   * Disconnects the shared MutationObserver and clears pending disconnect timers.
+   * Purpose: Stop observation after page stabilizes to reduce long-lived callback overhead.
+   * Necessity: Observer is only needed during dynamic render bursts and route transitions.
+   */
+  function disconnectConsolidatedObserver() {
+    if (observerDisconnectTimer) {
+      window.clearTimeout(observerDisconnectTimer);
+      observerDisconnectTimer = 0;
+    }
+
+    if (consolidatedObserver) {
+      consolidatedObserver.disconnect();
+      consolidatedObserver = null;
+    }
+  }
+
+  /**
+   * Schedules observer shutdown after a short idle period.
+   * Purpose: Keep observer active during render bursts, then detach automatically.
+   * Necessity: Balances responsiveness with lower steady-state CPU usage.
+   */
+  function scheduleObserverDisconnect() {
+    if (observerDisconnectTimer) {
+      window.clearTimeout(observerDisconnectTimer);
+    }
+
+    observerDisconnectTimer = window.setTimeout(() => {
+      disconnectConsolidatedObserver();
+    }, OBSERVER_IDLE_DISCONNECT_MS);
+  }
+
+  /**
+   * Ensures a single shared MutationObserver is connected for dynamic page updates.
+   * Purpose: Re-attach observer only when needed, using scoped root + filtered callback.
+   * Necessity: SPA-like updates on FP pages require temporary observation for toolbar rebuild.
+   */
+  function ensureConsolidatedObserver() {
+    if (consolidatedObserver || !document.body) return;
+
+    const rootNode = getObserverRootNode();
+    if (!rootNode) return;
+
+    consolidatedObserver = new MutationObserver((mutations) => {
+      if (isInitRunning) return;
+
+      const hasStructuralChange = mutations.some(
+        (mutation) =>
+          mutation.type === "childList" &&
+          ((mutation.addedNodes && mutation.addedNodes.length > 0) ||
+            (mutation.removedNodes && mutation.removedNodes.length > 0)),
+      );
+
+      if (!hasStructuralChange) return;
+
+      scheduleConsolidatedInit();
+      scheduleObserverDisconnect();
+    });
+
+    consolidatedObserver.observe(rootNode, { childList: true, subtree: true });
+    scheduleObserverDisconnect();
+  }
+
   function runConsolidatedInit() {
     const ctx = getRouteContext();
     isInitRunning = true;
@@ -1033,6 +1114,7 @@
       enforceTopRightButtonOrder();
     } finally {
       isInitRunning = false;
+      scheduleObserverDisconnect();
     }
   }
 
@@ -1062,20 +1144,15 @@
    */
   function bootstrapConsolidatedInit() {
     scheduleConsolidatedInit();
+    ensureConsolidatedObserver();
 
-    window.addEventListener("popstate", scheduleConsolidatedInit);
-    window.addEventListener("hashchange", scheduleConsolidatedInit);
+    const onRouteChange = () => {
+      ensureConsolidatedObserver();
+      scheduleConsolidatedInit();
+    };
 
-    if (document.body) {
-      const observer = new MutationObserver(() => {
-        // Only allow re-init triggered by MutationObserver if not already running
-        if (!isInitRunning) {
-          scheduleConsolidatedInit();
-        }
-      });
-
-      observer.observe(document.body, { childList: true, subtree: true });
-    }
+    window.addEventListener("popstate", onRouteChange);
+    window.addEventListener("hashchange", onRouteChange);
   }
 
   if (document.readyState === "loading") {


### PR DESCRIPTION
## Description
Merge `misc/release-20-bump` into `master` to deliver the CP
consolidated tools v2 release line together with related FP consolidated
metadata/script updates.

## Commit-driven Summary
This branch combines a broad sequence of CP-focused changes plus final
release/version alignment:
- Introduces CP v2 release/version bump (`2.0.0`)
- Adds actionable toolbar workflows (IXF import request, carrierfac
  approve/reject, overview copy of visible change links)
- Expands status/header badges (RIR, IXF, IRR AS-SET, IXF member link)
- Improves API/OpenAPI alignment and request plumbing (`pdbFetch`,
  `pdbPost`, centralized API URL/resource mapping, malformed payload
  diagnostics)
- Improves UX consistency (entity-specific frontend/website labels,
  stable link targets, no-op feedback for Update Name)
- Refactors internals for maintainability (event bus for field change
  routing, policy constants extraction, slug-map unification, cache
  schema versioning, extensive JSDoc coverage)
- Includes targeted bug fixes/perf improvements (multi-select reset,
  social_media reset shape, rendered-first status precedence, reduced
  API calls where entity responses already contain org_name)

## Files Changed
- `user.js/peeringdb-cp-consolidated-tools.meta.js`
- `user.js/peeringdb-cp-consolidated-tools.user.js`
- `user.js/peeringdb-fp-consolidated-tools.meta.js`
- `user.js/peeringdb-fp-consolidated-tools.user.js`

## Diff Stats
- 4 files changed
- 2883 insertions
- 172 deletions

## Testing
- Commit history records repeated diagnostics checks with no reported
  userscript/meta diagnostics errors.
- No additional runtime/integration test pass was executed during this
  PR creation step.

## Notes
PR-only workflow requested (no GitHub issue linkage).
