### PR TITLE
fix(cp): harden net naming and delete visibility

### DIFF
--- a/user.js/peeringdb-cp-consolidated-tools.meta.js
+++ b/user.js/peeringdb-cp-consolidated-tools.meta.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         PeeringDB CP - Consolidated Tools
 // @namespace    https://www.peeringdb.com/cp/
-// @version      2.0.1.20260323
+// @version      2.0.2.20260323
 // @description  Consolidated CP userscript with strict route-isolated modules for facility/network/user/entity workflows
 // @author       <chriztoffer@peeringdb.com>
 // @match        https://www.peeringdb.com/cp/peeringdb_server/*/*/change/*

--- a/user.js/peeringdb-cp-consolidated-tools.meta.js
+++ b/user.js/peeringdb-cp-consolidated-tools.meta.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         PeeringDB CP - Consolidated Tools
 // @namespace    https://www.peeringdb.com/cp/
-// @version      2.0.3.20260323
+// @version      2.0.4.20260323
 // @description  Consolidated CP userscript with strict route-isolated modules for facility/network/user/entity workflows
 // @author       <chriztoffer@peeringdb.com>
 // @match        https://www.peeringdb.com/cp/peeringdb_server/*/*/change/*

--- a/user.js/peeringdb-cp-consolidated-tools.meta.js
+++ b/user.js/peeringdb-cp-consolidated-tools.meta.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         PeeringDB CP - Consolidated Tools
 // @namespace    https://www.peeringdb.com/cp/
-// @version      2.0.0.20260323
+// @version      2.0.1.20260323
 // @description  Consolidated CP userscript with strict route-isolated modules for facility/network/user/entity workflows
 // @author       <chriztoffer@peeringdb.com>
 // @match        https://www.peeringdb.com/cp/peeringdb_server/*/*/change/*

--- a/user.js/peeringdb-cp-consolidated-tools.meta.js
+++ b/user.js/peeringdb-cp-consolidated-tools.meta.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         PeeringDB CP - Consolidated Tools
 // @namespace    https://www.peeringdb.com/cp/
-// @version      2.0.2.20260323
+// @version      2.0.3.20260323
 // @description  Consolidated CP userscript with strict route-isolated modules for facility/network/user/entity workflows
 // @author       <chriztoffer@peeringdb.com>
 // @match        https://www.peeringdb.com/cp/peeringdb_server/*/*/change/*

--- a/user.js/peeringdb-cp-consolidated-tools.user.js
+++ b/user.js/peeringdb-cp-consolidated-tools.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         PeeringDB CP - Consolidated Tools
 // @namespace    https://www.peeringdb.com/cp/
-// @version      2.0.3.20260323
+// @version      2.0.4.20260323
 // @description  Consolidated CP userscript with strict route-isolated modules for facility/network/user/entity workflows
 // @author       <chriztoffer@peeringdb.com>
 // @match        https://www.peeringdb.com/cp/peeringdb_server/*
@@ -25,7 +25,7 @@
   "use strict";
 
   const MODULE_PREFIX = "pdbCpConsolidated";
-  const SCRIPT_VERSION = "2.0.3.20260323";
+  const SCRIPT_VERSION = "2.0.4.20260323";
   const DUMMY_ORG_ID = 20525;
   const DISABLED_MODULES_STORAGE_KEY = `${MODULE_PREFIX}.disabledModules`;
   const USER_AGENT_STORAGE_KEY = `${MODULE_PREFIX}.userAgent`;
@@ -2875,6 +2875,115 @@
   }
 
   /**
+   * Ensures CSS styles are available for inline rows marked for deletion.
+   * Purpose: Make pending inline deletions visually obvious before save.
+   * Necessity: Grappelli delete checkboxes can be easy to miss in dense tabular inlines.
+   */
+  function ensureInlineDeleteHighlightStyles() {
+    const styleId = `${MODULE_PREFIX}InlineDeleteHighlightStyle`;
+    if (document.getElementById(styleId)) return;
+
+    const style = document.createElement("style");
+    style.id = styleId;
+    style.textContent = `
+      .${MODULE_PREFIX}InlineMarkedDelete {
+        background: linear-gradient(
+          90deg,
+          rgba(244, 67, 54, 0.28) 0%,
+          rgba(244, 67, 54, 0.16) 100%
+        ) !important;
+        outline: 2px solid rgba(198, 40, 40, 0.9);
+        outline-offset: -2px;
+        box-shadow: inset 0 0 0 9999px rgba(244, 67, 54, 0.12);
+      }
+
+      .${MODULE_PREFIX}InlineMarkedDelete .grp-td {
+        background-color: transparent !important;
+      }
+
+      .${MODULE_PREFIX}InlineMarkedDelete .grp-tools-container {
+        background: rgba(183, 28, 28, 0.2) !important;
+      }
+    `;
+    document.head.appendChild(style);
+  }
+
+  /**
+   * Returns the owning inline row element for a delete control.
+   * @param {Element|null} element - Delete checkbox or delete icon descendant.
+   * @returns {HTMLElement|null} Owning `.form-row.grp-dynamic-form` element.
+   */
+  function getInlineDeleteRowElement(element) {
+    return element?.closest(".form-row.grp-dynamic-form") || null;
+  }
+
+  /**
+   * Applies/removes the marked-for-deletion visual state on an inline row.
+   * @param {HTMLElement|null} row - Inline row element.
+   * @param {boolean} isMarkedForDelete - Whether delete checkbox is active.
+   */
+  function setInlineDeleteRowHighlight(row, isMarkedForDelete) {
+    if (!row) return;
+    row.classList.toggle(`${MODULE_PREFIX}InlineMarkedDelete`, Boolean(isMarkedForDelete));
+  }
+
+  /**
+   * Syncs highlight state for one inline row based on its DELETE checkbox value.
+   * @param {HTMLElement|null} row - Inline row element.
+   */
+  function syncInlineDeleteRowHighlight(row) {
+    if (!row) return;
+    const deleteCheckbox = qs('input[type="checkbox"][name$="-DELETE"]', row);
+    setInlineDeleteRowHighlight(row, Boolean(deleteCheckbox?.checked));
+  }
+
+  /**
+   * Binds delegated listeners that highlight rows when inline delete is toggled.
+   * Purpose: Make delete actions (cross icon/checkbox) highly visible instantly.
+   * Necessity: Inline rows are dynamic; delegated binding covers existing and added rows.
+   * @returns {Function|null} Dispose function that removes listeners.
+   */
+  function bindInlineDeleteHighlightReactivity() {
+    const container = qs("#grp-content-container");
+    if (!container || container.hasAttribute("data-pdb-cp-inline-delete-highlight-bound")) {
+      return null;
+    }
+
+    ensureInlineDeleteHighlightStyles();
+    container.setAttribute("data-pdb-cp-inline-delete-highlight-bound", "1");
+
+    qsa(".form-row.grp-dynamic-form", container).forEach((row) => {
+      syncInlineDeleteRowHighlight(row);
+    });
+
+    const onChange = (event) => {
+      const target = event?.target;
+      if (!target?.matches?.('input[type="checkbox"][name$="-DELETE"]')) return;
+      syncInlineDeleteRowHighlight(getInlineDeleteRowElement(target));
+    };
+
+    const onClick = (event) => {
+      const deleteIcon = event?.target?.closest?.("a.grp-delete-handler");
+      if (!deleteIcon) return;
+
+      const row = getInlineDeleteRowElement(deleteIcon);
+      // Grappelli toggles checkbox in its own click handler; defer one tick.
+      setTimeout(() => {
+        syncInlineDeleteRowHighlight(row);
+      }, 0);
+    };
+
+    container.addEventListener("change", onChange);
+    container.addEventListener("click", onClick);
+
+    return () => {
+      container.removeEventListener("change", onChange);
+      container.removeEventListener("click", onClick);
+      container.removeAttribute("data-pdb-cp-inline-delete-highlight-bound");
+    };
+  }
+
+  /**
    * Normalizes text copied from rendered field contents.
    * Purpose: Remove excessive whitespace while preserving readable one-line output.
    * Necessity: Rendered HTML often contains line breaks and spacing artifacts.
@@ -4028,6 +4137,12 @@
       run: () => {
         addCopyButtonsToRenderedFields();
       },
+    },
+    {
+      id: "inline-delete-row-highlights",
+      match: (ctx) => ctx.isEntityChangePage && ctx.entity === "network",
+      preconditions: () => Boolean(qs("#grp-content-container .inline-group.grp-tabular")),
+      run: () => bindInlineDeleteHighlightReactivity(),
     },
     {
       id: "facility-google-maps",

--- a/user.js/peeringdb-cp-consolidated-tools.user.js
+++ b/user.js/peeringdb-cp-consolidated-tools.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         PeeringDB CP - Consolidated Tools
 // @namespace    https://www.peeringdb.com/cp/
-// @version      2.0.1.20260323
+// @version      2.0.2.20260323
 // @description  Consolidated CP userscript with strict route-isolated modules for facility/network/user/entity workflows
 // @author       <chriztoffer@peeringdb.com>
 // @match        https://www.peeringdb.com/cp/peeringdb_server/*
@@ -25,7 +25,7 @@
   "use strict";
 
   const MODULE_PREFIX = "pdbCpConsolidated";
-  const SCRIPT_VERSION = "2.0.1.20260323";
+  const SCRIPT_VERSION = "2.0.2.20260323";
   const DUMMY_ORG_ID = 20525;
   const DISABLED_MODULES_STORAGE_KEY = `${MODULE_PREFIX}.disabledModules`;
   const USER_AGENT_STORAGE_KEY = `${MODULE_PREFIX}.userAgent`;
@@ -3036,6 +3036,30 @@
   }
 
   /**
+   * Determines whether network Update Name should force-append ` (AS<asn>)`.
+   * Purpose: Apply deterministic disambiguation for known risky name patterns
+   * during the first Update Name submit, not only after duplicate retries.
+   * Necessity: Certain names (for example IPv4-leading labels) are likely to
+   * collide operationally and benefit from explicit ASN suffixing immediately.
+   * @param {string} name - Candidate network name before forced suffixing.
+   * @returns {boolean} True when ASN suffix should be forced.
+   */
+  function shouldForceNetworkNameAsnSuffix(name) {
+    const normalized = String(name || "").trim();
+    if (!normalized) return false;
+
+    const ipv4LeadingMatch = normalized.match(/^\s*(\d{1,3}(?:\.\d{1,3}){3})(?=\s|\b|$|[-–—:])/);
+    if (!ipv4LeadingMatch) return false;
+
+    const octets = ipv4LeadingMatch[1].split(".");
+    if (octets.length !== 4) return false;
+    return octets.every((octet) => {
+      const value = Number.parseInt(octet, 10);
+      return Number.isInteger(value) && value >= 0 && value <= 255;
+    });
+  }
+
+  /**
    * Persists one-time retry metadata for network Update Name submit flow.
    * Purpose: Bridge state across page reload after first save attempt.
    * Necessity: Duplicate-name validation appears only after form submit.
@@ -4084,7 +4108,10 @@
                 }
               }
 
-              const nextName = `${baseName}${appendName}`;
+              let nextName = `${baseName}${appendName}`;
+              if (ctx.entity === "network" && shouldForceNetworkNameAsnSuffix(nextName)) {
+                nextName = buildNetworkNameAsnRetryVariant(nextName, getInputValue("#id_asn")) || nextName;
+              }
               const currentName = getInputValue("#id_name");
               if (nextName === currentName) {
                 pulseToolbarButton(event?.target, "No-op");

--- a/user.js/peeringdb-cp-consolidated-tools.user.js
+++ b/user.js/peeringdb-cp-consolidated-tools.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         PeeringDB CP - Consolidated Tools
 // @namespace    https://www.peeringdb.com/cp/
-// @version      2.0.0.20260323
+// @version      2.0.1.20260323
 // @description  Consolidated CP userscript with strict route-isolated modules for facility/network/user/entity workflows
 // @author       <chriztoffer@peeringdb.com>
 // @match        https://www.peeringdb.com/cp/peeringdb_server/*
@@ -25,7 +25,7 @@
   "use strict";
 
   const MODULE_PREFIX = "pdbCpConsolidated";
-  const SCRIPT_VERSION = "2.0.0.20260323";
+  const SCRIPT_VERSION = "2.0.1.20260323";
   const DUMMY_ORG_ID = 20525;
   const DISABLED_MODULES_STORAGE_KEY = `${MODULE_PREFIX}.disabledModules`;
   const USER_AGENT_STORAGE_KEY = `${MODULE_PREFIX}.userAgent`;
@@ -46,6 +46,8 @@
   const ORG_NAME_CACHE_STORAGE_PREFIX = `${MODULE_PREFIX}.orgNameCache.`;
   const NETWORK_NAME_SCAN_CACHE_KEY = `${MODULE_PREFIX}.networkNameScanCache.v8`;
   const NETWORK_NAME_SCAN_CACHE_TTL_MS = CACHE_TTL_MS;
+  const NETWORK_UPDATE_NAME_RETRY_STORAGE_PREFIX = `${MODULE_PREFIX}.networkUpdateNameRetry.`;
+  const NETWORK_UPDATE_NAME_RETRY_TTL_MS = 15 * 60 * 1000;
   const NETWORK_NAME_SCAN_PAGE_SIZE = 2000;
   const NETWORK_NAME_SCAN_TARGET_COUNT = 0;
   const NETWORK_NAME_SCAN_MAX_REQUESTS = 40;
@@ -485,21 +487,33 @@
   /**
    * Returns storage for domain-scoped cache entries.
    * Purpose: Share short-lived cache payloads across tabs on the same origin.
-   * Necessity: sessionStorage is tab-scoped; localStorage enables cross-tab reuse.
-   * Falls back to sessionStorage when localStorage is unavailable.
-   * @returns {Storage|null} localStorage (preferred), sessionStorage (fallback), or null.
+   * Necessity: tab-scoped storage breaks cross-tab consistency; localStorage enables cross-tab reuse.
+   * @returns {Storage|null} localStorage instance, or null when unavailable.
    */
   function getDomainCacheStorage() {
     try {
       if (window.localStorage) return window.localStorage;
     } catch (_error) {
-      // Fall through to sessionStorage fallback.
+      // Ignore; cache persistence will be unavailable.
     }
 
+    return null;
+  }
+
+  /**
+   * Returns storage for tab-scoped transient state.
+   * Purpose: Isolate ephemeral per-tab state (e.g. one-shot retry payloads) from
+   * domain-wide localStorage cache so cross-tab reads cannot accidentally replay
+   * a retry that belongs to a different browser context.
+   * Necessity: sessionStorage is cleared when the tab closes, preventing stale
+   * retry state from resurecting in a future session on the same origin.
+   * @returns {Storage|null} sessionStorage instance, or null when unavailable.
+   */
+  function getTabSessionStorage() {
     try {
       if (window.sessionStorage) return window.sessionStorage;
     } catch (_error) {
-      // Ignore; cache persistence will be unavailable.
+      // Ignore; tab-session persistence will be unavailable.
     }
 
     return null;
@@ -696,16 +710,17 @@
    * Generates or retrieves a persistent session UUID for the browser session.
    * Purpose: Provides a unique identifier for correlating requests within a session.
    * Necessity: Enables server-side analytics and request tracking without exposing device fingerprint.
-   * UUID persists across page reloads but is cleared when tab/session closes.
+   * UUID persists across page reloads and tabs on the same origin.
    * @returns {string} Session UUID string (generated once per browser session).
    */
   function getSessionUuid() {
     const sessionKey = SESSION_UUID_STORAGE_KEY;
-    let uuid = window.sessionStorage?.getItem(sessionKey);
+    const storage = getDomainCacheStorage();
+    let uuid = storage?.getItem(sessionKey);
     if (!uuid) {
       uuid = `${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
-      if (window.sessionStorage) {
-        window.sessionStorage.setItem(sessionKey, uuid);
+      if (storage) {
+        storage.setItem(sessionKey, uuid);
       }
     }
     return uuid;
@@ -2974,6 +2989,226 @@
   }
 
   /**
+   * Builds storage key for persisted one-time network update-name retry state.
+   * Purpose: Keep retry metadata isolated per network record.
+   * Necessity: Enables safe post-submit retry on the next page load.
+   * @param {string|number} networkId - CP network record ID.
+   * @returns {string} Namespaced storage key.
+   */
+  function getNetworkUpdateNameRetryStorageKey(networkId) {
+    const normalizedNetworkId = String(networkId || "").trim();
+    if (!normalizedNetworkId) return "";
+    return `${NETWORK_UPDATE_NAME_RETRY_STORAGE_PREFIX}${normalizedNetworkId}`;
+  }
+
+  /**
+   * Extracts ASN digits from user/API values.
+   * Purpose: Normalize ASN for deterministic retry suffixes.
+   * Necessity: ASN values can include spaces or optional AS prefixes.
+   * @param {string|number} asnInput - Raw ASN value.
+   * @returns {string} Numeric ASN text, or empty string when invalid.
+   */
+  function normalizeAsnForNameSuffix(asnInput) {
+    const cleaned = String(asnInput || "").replace(/^AS\s*/i, "").trim();
+    const parsed = Number.parseInt(cleaned, 10);
+    if (!Number.isInteger(parsed) || parsed <= 0) return "";
+    return String(parsed);
+  }
+
+  /**
+   * Builds one retry variant by appending ` (AS<asn>)` when possible.
+   * Purpose: Resolve duplicate-name validation conflicts deterministically.
+   * Necessity: Some names collide only after submit-side uniqueness checks.
+   * @param {string} name - Candidate network name.
+   * @param {string|number} asnInput - ASN source value.
+   * @returns {string} Retry candidate name, or empty string when unavailable.
+   */
+  function buildNetworkNameAsnRetryVariant(name, asnInput) {
+    const baseName = String(name || "").trim();
+    if (!baseName) return "";
+
+    const normalizedAsn = normalizeAsnForNameSuffix(asnInput);
+    if (!normalizedAsn) return "";
+
+    const retrySuffix = ` (AS${normalizedAsn})`;
+    if (baseName.endsWith(retrySuffix)) return baseName;
+    return `${baseName}${retrySuffix}`;
+  }
+
+  /**
+   * Persists one-time retry metadata for network Update Name submit flow.
+   * Purpose: Bridge state across page reload after first save attempt.
+   * Necessity: Duplicate-name validation appears only after form submit.
+   * @param {{
+   *   networkId: string|number,
+   *   originalName: string,
+   *   retryName: string,
+   *   attempts?: number,
+   * }} payload - Retry metadata payload.
+   */
+  function setPendingNetworkUpdateNameRetry(payload) {
+    const networkId = String(payload?.networkId || "").trim();
+    const originalName = String(payload?.originalName || "").trim();
+    const retryName = String(payload?.retryName || "").trim();
+    const attempts = Number(payload?.attempts || 0);
+    if (!networkId || !originalName || !retryName) return;
+
+    const storageKey = getNetworkUpdateNameRetryStorageKey(networkId);
+    if (!storageKey) return;
+
+    try {
+      const storage = getTabSessionStorage();
+      storage?.setItem(
+        storageKey,
+        JSON.stringify({
+          networkId,
+          originalName,
+          retryName,
+          attempts,
+          expiresAt: Date.now() + NETWORK_UPDATE_NAME_RETRY_TTL_MS,
+        }),
+      );
+    } catch (_error) {
+      // Ignore storage errors; retry remains best-effort.
+    }
+  }
+
+  /**
+   * Reads pending network update-name retry metadata when still valid.
+   * Purpose: Resume one-time retry workflow after save-triggered page reload.
+   * Necessity: Expired/stale payloads must be ignored to prevent unintended edits.
+   * @param {string|number} networkId - CP network record ID.
+   * @returns {{networkId: string, originalName: string, retryName: string, attempts: number}|null}
+   */
+  function getPendingNetworkUpdateNameRetry(networkId) {
+    const storageKey = getNetworkUpdateNameRetryStorageKey(networkId);
+    if (!storageKey) return null;
+
+    try {
+      const storage = getTabSessionStorage();
+      const raw = storage?.getItem(storageKey);
+      if (!raw) return null;
+
+      const parsed = JSON.parse(raw);
+      const expiresAt = Number(parsed?.expiresAt || 0);
+      if (!Number.isFinite(expiresAt) || Date.now() >= expiresAt) {
+        storage?.removeItem(storageKey);
+        return null;
+      }
+
+      const originalName = String(parsed?.originalName || "").trim();
+      const retryName = String(parsed?.retryName || "").trim();
+      if (!originalName || !retryName) {
+        storage?.removeItem(storageKey);
+        return null;
+      }
+
+      return {
+        networkId: String(parsed?.networkId || "").trim(),
+        originalName,
+        retryName,
+        attempts: Math.max(0, Number.parseInt(String(parsed?.attempts ?? 0), 10) || 0),
+      };
+    } catch (_error) {
+      return null;
+    }
+  }
+
+  /**
+   * Clears pending network update-name retry metadata.
+   * Purpose: Stop retry loop once success/failure outcome is known.
+   * Necessity: Prevents stale retries from affecting later manual edits.
+   * @param {string|number} networkId - CP network record ID.
+   */
+  function clearPendingNetworkUpdateNameRetry(networkId) {
+    const storageKey = getNetworkUpdateNameRetryStorageKey(networkId);
+    if (!storageKey) return;
+
+    try {
+      const storage = getTabSessionStorage();
+      storage?.removeItem(storageKey);
+    } catch (_error) {
+      // Ignore storage cleanup errors.
+    }
+  }
+
+  /**
+   * Detects duplicate network-name validation errors on the current form.
+   * Purpose: Trigger retry only for the specific uniqueness validation failure.
+   * Necessity: Avoids overriding names for unrelated form errors.
+   * @returns {boolean} True when duplicate-name validation is present.
+   */
+  function hasDuplicateNetworkNameValidationError() {
+    const errorRows = qsa("#id_name_error li, .name .errorlist li");
+    if (!errorRows.length) return false;
+
+    return errorRows.some((item) =>
+      /name is already in use by another network/i.test(String(item?.textContent || "").trim()),
+    );
+  }
+
+  /**
+   * Applies one automatic retry for Update Name when duplicate-name error appears.
+   * Purpose: Retry with ` (AS<asn>)` suffix after server-side uniqueness rejection.
+   * Necessity: Duplicate validation is only known after submit, requiring reload-time retry.
+   * @param {{ entity: string, entityId: string, isEntityChangePage: boolean }} ctx - Route context.
+   * @returns {boolean} True when retry save was triggered.
+   */
+  function maybeRetryNetworkUpdateNameAfterDuplicate(ctx) {
+    if (!ctx?.isEntityChangePage || ctx.entity !== "network") return false;
+
+    const pending = getPendingNetworkUpdateNameRetry(ctx.entityId);
+    if (!pending) return false;
+
+    const currentName = getInputValue("#id_name");
+    const hasDuplicateError = hasDuplicateNetworkNameValidationError();
+
+    if (!hasDuplicateError) {
+      clearPendingNetworkUpdateNameRetry(ctx.entityId);
+      return false;
+    }
+
+    if (currentName === pending.retryName) {
+      clearPendingNetworkUpdateNameRetry(ctx.entityId);
+      notifyUser({
+        title: "PeeringDB CP",
+        text: "Update Name retry also failed (duplicate). Please set a unique name manually.",
+      });
+      return false;
+    }
+
+    if (currentName !== pending.originalName) {
+      clearPendingNetworkUpdateNameRetry(ctx.entityId);
+      return false;
+    }
+
+    if (pending.attempts >= 1) {
+      clearPendingNetworkUpdateNameRetry(ctx.entityId);
+      return false;
+    }
+
+    setInputValue("#id_name", pending.retryName);
+    setPendingNetworkUpdateNameRetry({
+      networkId: ctx.entityId,
+      originalName: pending.originalName,
+      retryName: pending.retryName,
+      attempts: pending.attempts + 1,
+    });
+
+    const triggered = clickSaveAndContinue();
+    if (!triggered) {
+      clearPendingNetworkUpdateNameRetry(ctx.entityId);
+      return false;
+    }
+
+    notifyUser({
+      title: "PeeringDB CP",
+      text: `Update Name retry: attempting '${pending.retryName}'.`,
+    });
+    return true;
+  }
+
+  /**
    * Reads a readonly field value from a form row by its visible label text.
    * Purpose: Prefer values already rendered on the change form over stale API payloads.
    * Necessity: Some readonly values can differ from API fetch timing/state on page load.
@@ -3782,6 +4017,14 @@
       },
     },
     {
+      id: "network-update-name-retry-on-duplicate",
+      match: (ctx) => ctx.isEntityChangePage && ctx.entity === "network",
+      preconditions: () => Boolean(qs("#id_name") && qs("form")),
+      run: (ctx) => {
+        maybeRetryNetworkUpdateNameAfterDuplicate(ctx);
+      },
+    },
+    {
       id: "set-entity-name-equal-org-name",
       match: (ctx) =>
         ctx.isEntityChangePage && ENTITY_TYPES.has(ctx.entity),
@@ -3852,12 +4095,41 @@
                 return;
               }
 
+              let queuedRetryName = "";
+              if (ctx.entity === "network") {
+                queuedRetryName = buildNetworkNameAsnRetryVariant(nextName, getInputValue("#id_asn"));
+                if (queuedRetryName && queuedRetryName !== nextName) {
+                  setPendingNetworkUpdateNameRetry({
+                    networkId: ctx.entityId,
+                    originalName: nextName,
+                    retryName: queuedRetryName,
+                    attempts: 0,
+                  });
+                } else {
+                  clearPendingNetworkUpdateNameRetry(ctx.entityId);
+                }
+              }
+
               markDeletedNetworkInlinesForDeletion();
               setInputValue("#id_name", nextName);
-              clickSaveAndContinue();
+              const didSubmit = clickSaveAndContinue();
+              if (!didSubmit) {
+                if (ctx.entity === "network") {
+                  clearPendingNetworkUpdateNameRetry(ctx.entityId);
+                }
+                notifyUser({
+                  title: "PeeringDB CP",
+                  text: "Update Name: failed to trigger save action.",
+                });
+                return;
+              }
+
               notifyUser({
                 title: "PeeringDB CP",
-                text: `Update Name: saved '${nextName}'.`,
+                text:
+                  ctx.entity === "network" && queuedRetryName
+                    ? `Update Name: saved '${nextName}'. Auto-retry is armed for duplicate-name errors.`
+                    : `Update Name: saved '${nextName}'.`,
               });
             } finally {
               endActionLock(actionLockKey);

--- a/user.js/peeringdb-cp-consolidated-tools.user.js
+++ b/user.js/peeringdb-cp-consolidated-tools.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         PeeringDB CP - Consolidated Tools
 // @namespace    https://www.peeringdb.com/cp/
-// @version      2.0.2.20260323
+// @version      2.0.3.20260323
 // @description  Consolidated CP userscript with strict route-isolated modules for facility/network/user/entity workflows
 // @author       <chriztoffer@peeringdb.com>
 // @match        https://www.peeringdb.com/cp/peeringdb_server/*
@@ -25,7 +25,7 @@
   "use strict";
 
   const MODULE_PREFIX = "pdbCpConsolidated";
-  const SCRIPT_VERSION = "2.0.2.20260323";
+  const SCRIPT_VERSION = "2.0.3.20260323";
   const DUMMY_ORG_ID = 20525;
   const DISABLED_MODULES_STORAGE_KEY = `${MODULE_PREFIX}.disabledModules`;
   const USER_AGENT_STORAGE_KEY = `${MODULE_PREFIX}.userAgent`;
@@ -1073,6 +1073,122 @@
     input.dispatchEvent(new Event("input", { bubbles: true }));
     input.dispatchEvent(new Event("change", { bubbles: true }));
     return true;
+  }
+
+  /**
+   * Resolves editable long-name input element for network forms.
+   * Purpose: Keep Long Name reads/writes resilient to minor template/id changes.
+   * Necessity: CP forms may render this field with different IDs depending on
+   * model/version, so lookup must support both ID and label-based discovery.
+   * @returns {HTMLInputElement|HTMLTextAreaElement|null} Long Name input element.
+   */
+  function getNetworkLongNameInputElement() {
+    const idCandidates = ["#id_name_long", "#id_long_name", "#id_aka"];
+    for (const selector of idCandidates) {
+      const element = qs(selector);
+      if (element) return element;
+    }
+
+    const row = qsa(".form-row").find((item) => {
+      const label = normalizeRenderedCopyText(
+        (qs(".c-1 label", item) || qs(".c-1", item))?.textContent || "",
+      ).toLowerCase();
+      return label === "long name";
+    });
+    if (!row) return null;
+
+    return (
+      qs(".c-2 input[type='text']", row) ||
+      qs(".c-2 textarea", row) ||
+      qs("input[type='text']", row) ||
+      qs("textarea", row) ||
+      null
+    );
+  }
+
+  /**
+   * Reads current Long Name field value for network change forms.
+   * @returns {string} Trimmed long-name value, or empty string when unavailable.
+   */
+  function getNetworkLongNameValue() {
+    const input = getNetworkLongNameInputElement();
+    if (!input) return "";
+    return String(input.value || "").trim();
+  }
+
+  /**
+   * Sets Long Name field value with change/input events.
+   * @param {string} value - Value to set in Long Name.
+   * @returns {boolean} True when Long Name field was found and updated.
+   */
+  function setNetworkLongNameValue(value) {
+    const input = getNetworkLongNameInputElement();
+    if (!input) return false;
+
+    const normalized = String(value || "").trim();
+    input.value = normalized;
+    if ("defaultValue" in input) {
+      input.defaultValue = normalized;
+    }
+    input.setAttribute("value", normalized);
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    input.dispatchEvent(new Event("change", { bubbles: true }));
+    return true;
+  }
+
+  /**
+   * Strips trailing legal company-type suffixes from a name.
+   * Purpose: Keep network short Name concise while preserving full legal form
+   * in Long Name.
+   * Necessity: Organizations frequently include legal suffixes (e.g. LTDA, SAS)
+   * that are better suited for Long Name than short Name.
+   * @param {string} name - Full organization name.
+   * @returns {string} Name without trailing company-type suffix tokens.
+   */
+  function stripCompanyTypeSuffix(name) {
+    const original = String(name || "").trim().replace(/\s+/g, " ");
+    if (!original) return "";
+
+    const legalSuffixPatterns = [
+      "S\\.?\\s*A\\.?\\s*S\\.?", // SAS / S.A.S.
+      "S\\.?\\s*C\\.?\\s*C\\.?", // SCC / S.C.C.
+      "L\\.?\\s*T\\.?\\s*D\\.?\\s*A\\.?", // LTDA / L.T.D.A.
+      "LTD\\.?",
+      "LLC",
+      "LLP",
+      "INC\\.?",
+      "CORP\\.?",
+      "S\\.?\\s*A\\.?", // SA / S.A.
+      "C\\.?\\s*A\\.?", // CA / C.A.
+      "S\\.?\\s*R\\.?\\s*L\\.?", // SRL / S.R.L.
+      "S\\.?\\s*R\\.?\\s*O\\.?", // SRO / S.R.O.
+      "S\\.?\\s*A\\.?\\s*R\\.?\\s*L\\.?", // SARL / S.A.R.L.
+      "S\\.?\\s*P\\.?\\s*A\\.?", // SPA / S.P.A.
+      "G\\.?\\s*M\\.?\\s*B\\.?\\s*H\\.?", // GmbH / G.m.b.H.
+      "G\\.?\\s*M\\.?\\s*B\\.?\\s*H\\.?\\s*&\\s*CO\\.?\\s*KG\\.?", // GmbH & Co. KG
+      "AG",
+      "BV",
+      "B\\.?\\s*V\\.?", // BV / B.V.
+      "NV",
+      "PTE\\.?",
+      "PTY\\.?",
+      "PLC",
+      "EIRELI",
+      "MEI",
+    ];
+    const suffixRegex = new RegExp(
+      `(?:[\\s,.-]+)(?:${legalSuffixPatterns.join("|")})\\.?[\\s,.-]*$`,
+      "i",
+    );
+
+    let candidate = original;
+    let previous = "";
+    while (candidate && candidate !== previous && suffixRegex.test(candidate)) {
+      previous = candidate;
+      candidate = candidate.replace(suffixRegex, "").trim().replace(/[\s,.-]+$/g, "").trim();
+    }
+
+    return candidate || original;
   }
 
   /**
@@ -4108,12 +4224,25 @@
                 }
               }
 
+              const fullName = String(baseName || "").trim();
+              let nextLongName = "";
               let nextName = `${baseName}${appendName}`;
-              if (ctx.entity === "network" && shouldForceNetworkNameAsnSuffix(nextName)) {
-                nextName = buildNetworkNameAsnRetryVariant(nextName, getInputValue("#id_asn")) || nextName;
+
+              if (ctx.entity === "network") {
+                const compactNameBase = stripCompanyTypeSuffix(fullName) || fullName;
+                const detectedCompanySuffix = compactNameBase !== fullName;
+                nextLongName = detectedCompanySuffix ? fullName : "";
+                nextName = `${compactNameBase}${appendName}`;
+                if (shouldForceNetworkNameAsnSuffix(nextName)) {
+                  nextName = buildNetworkNameAsnRetryVariant(nextName, getInputValue("#id_asn")) || nextName;
+                }
               }
               const currentName = getInputValue("#id_name");
-              if (nextName === currentName) {
+              const currentLongName = ctx.entity === "network" ? getNetworkLongNameValue() : "";
+              const shouldUpdateLongName =
+                ctx.entity === "network" && nextLongName && nextLongName !== currentLongName;
+
+              if (nextName === currentName && !shouldUpdateLongName) {
                 pulseToolbarButton(event?.target, "No-op");
                 notifyUser({
                   title: "PeeringDB CP",
@@ -4138,6 +4267,9 @@
               }
 
               markDeletedNetworkInlinesForDeletion();
+              if (ctx.entity === "network" && nextLongName) {
+                setNetworkLongNameValue(nextLongName);
+              }
               setInputValue("#id_name", nextName);
               const didSubmit = clickSaveAndContinue();
               if (!didSubmit) {


### PR DESCRIPTION
## Description
Merge `feat/extend-n-enhance-consolidated-functionality` into `master`
to harden CP consolidated network update workflows and improve operator
clarity on network change pages.

This is a focused reliability + UX hardening series across four
sequential fixes.

## Scope summary
1. Correct one-shot duplicate-name retry storage scope and retry wiring
2. Force deterministic ASN suffixing for matched network name patterns
3. Preserve legal long names while normalizing short names
4. Make delete-marked inline rows highly visible before save

## Commit-driven breakdown

### 1) Duplicate-name retry + storage scope correction
- Adds tab-scoped transient retry storage (`sessionStorage`) for
  one-shot retry payloads
- Keeps domain-shared cache behavior for org/scan caches
- Adds retry constants, module wiring, and retry arming notification
- Release bump in this step: `2.0.1`

### 2) Deterministic ASN suffix first-attempt behavior
- Adds matching helper for when ASN suffix must be applied
- Appends ` (AS<asn>)` on first submit for matched names
- Retains duplicate retry fallback path
- Release bump in this step: `2.0.2`

### 3) Legal-form handling with long-name preservation
- Adds robust Long Name field find/read/write helpers
- Strips trailing legal suffixes for concise short Name
- Preserves full legal form in Long Name
- Improves suffix handling for dotted/compound GmbH variants
- Release bump in this step: `2.0.3`

### 4) Inline delete visibility hardening
- Adds high-contrast highlight styling for DELETE-marked inline rows
- Adds delegated checkbox/delete-icon reactivity and initial sync
- Registers module for network change pages
- Release bump in this step: `2.0.4`

## Files changed
- `user.js/peeringdb-cp-consolidated-tools.meta.js`
- `user.js/peeringdb-cp-consolidated-tools.user.js`

## Diff stats
- 2 files changed
- 562 insertions
- 16 deletions

## Validation notes
- Commit history records repeated diagnostics checks with no reported
  diagnostics errors in modified userscript/meta files
- Manual validation explicitly noted for legal-suffix/GmbH handling
- No additional automated runtime/integration suite was executed during
  PR authoring

## Backwards compatibility
- Non-matching name flows remain intact
- Retry fallback remains available
- Inline highlight is additive and only affects rows already marked for
  deletion

## Notes
- PR-only workflow requested (no GitHub issue linkage)
- Version references intentionally shown as semver only
