### PR TITLE
fix(build): retry only safe methods, not every request

### DIFF
--- a/user.js/lib/admincom-common.js
+++ b/user.js/lib/admincom-common.js
@@ -50,6 +50,13 @@ const REQUEST_TIMEOUT_MS = 15000;
 // Transient statuses worth retrying with backoff (rate limit / gateway).
 const RETRYABLE_STATUS = [429, 502, 503, 504];
 const MAX_RETRIES = 3;
+// Methods a failed request may be repeated for without the repeat itself being
+// a side effect. A 502/503/504 means the response was lost, NOT that the
+// request was: a DELETE that committed server-side and then timed out at the
+// gateway is indistinguishable here from one that never arrived. Replaying it
+// re-issues a write whose outcome is unknown, so writes are excluded and must
+// opt in per call via retryWrites: true.
+const SAFE_TO_RETRY_METHODS = ['GET', 'HEAD'];
 
 /**
  * Returns true when diagnostics/debug mode is enabled via localStorage.
@@ -139,13 +146,23 @@ function parseRetryAfterMs(value) {
  * long. Shared by both request wrappers below so the retry policy
  * (retryable-status list, Retry-After handling, backoff curve) is defined
  * exactly once.
+ * The method is part of the decision, not just the status. Retrying a write
+ * that may already have been applied is a correctness problem, not a
+ * performance one, so only SAFE_TO_RETRY_METHODS are retried unless the caller
+ * explicitly opts in with retryWrites.
  * @param {object} params
  * @param {?number} params.status - HTTP status, or null/undefined for a network-level failure.
  * @param {number} params.attempt - 1-based current attempt number.
  * @param {?string} [params.retryAfterHeader] - Raw Retry-After header value, if any.
+ * @param {string} [params.method] - HTTP method of the request. Defaults to GET
+ *   so an omitted method is treated as the safe case it almost always is.
+ * @param {boolean} [params.retryWrites] - Opt in to retrying a non-safe method.
+ *   Only set this where re-applying the write is known to be harmless.
  * @returns {{retryable: boolean, backoffMs: number}}
  */
-function classifyRetry({ status, attempt, retryAfterHeader }) {
+function classifyRetry({ status, attempt, retryAfterHeader, method = 'GET', retryWrites = false }) {
+  const safeMethod = SAFE_TO_RETRY_METHODS.includes(String(method || 'GET').toUpperCase());
+  if (!safeMethod && !retryWrites) return { retryable: false, backoffMs: 0 };
   const retryable = status == null || RETRYABLE_STATUS.includes(status);
   if (!retryable) return { retryable: false, backoffMs: 0 };
   const fromHeader = parseRetryAfterMs(retryAfterHeader);
@@ -158,24 +175,28 @@ function classifyRetry({ status, attempt, retryAfterHeader }) {
  * default timeout and retries transient failures with exponential backoff,
  * honoring a Retry-After response header when the server sends one.
  *
- * 429/5xx responses are retried for any method. A transport-level failure
- * (network error/timeout, as opposed to an HTTP error response) is only
- * retried for idempotent GETs by default -- pass retryTransportErrors: true
- * to opt in for a non-GET call known to be safe to replay. Pass retry:
- * false to disable retries entirely for a call.
+ * Only SAFE_TO_RETRY_METHODS (GET/HEAD) are retried, for both 429/5xx
+ * responses and transport-level failures. This previously retried 429/5xx for
+ * any method, which meant a write that had already been applied server-side
+ * could be re-issued when only the response was lost. Pass retryWrites: true
+ * to opt a non-safe method back in where re-applying it is known to be
+ * harmless, retryTransportErrors: true to opt a non-safe method into
+ * transport-failure retries specifically, or retry: false to disable retries
+ * entirely for a call.
  * @param {object} opts - GM_xmlhttpRequest options, plus onload/onerror/
- *   ontimeout callbacks, an optional `retry: false` full opt-out, and an
- *   optional `retryTransportErrors: true`.
+ *   ontimeout callbacks, an optional `retry: false` full opt-out, an optional
+ *   `retryWrites: true`, and an optional `retryTransportErrors: true`.
  * @param {number} [attempt] - 1-based current attempt number (internal,
  *   used for backoff calculation on recursive retries).
  */
 function gmRequestWithRetry(opts, attempt = 1) {
-  const { onload, onerror, ontimeout, retry, retryTransportErrors = false, ...rest } = opts;
-  const transportRetryable = (rest.method || 'GET').toUpperCase() === 'GET' || retryTransportErrors;
+  const { onload, onerror, ontimeout, retry, retryWrites = false, retryTransportErrors = false, ...rest } = opts;
+  const method = (rest.method || 'GET').toUpperCase();
+  const transportRetryable = SAFE_TO_RETRY_METHODS.includes(method) || retryWrites || retryTransportErrors;
 
   const scheduleRetry = (status, retryAfterHeader) => {
     if (retry === false || attempt >= MAX_RETRIES) return false;
-    const decision = classifyRetry({ status, attempt, retryAfterHeader });
+    const decision = classifyRetry({ status, attempt, retryAfterHeader, method, retryWrites });
     if (!decision.retryable) return false;
     dbg('http', `Retry ${attempt + 1}/${MAX_RETRIES} in ${decision.backoffMs}ms for`, rest.url);
     setTimeout(() => gmRequestWithRetry(opts, attempt + 1), decision.backoffMs);
@@ -210,9 +231,10 @@ function gmRequestWithRetry(opts, attempt = 1) {
  * AbortController on timeout.
  * @param {string} url
  * @param {object} [opts] - fetch() init, plus an optional `retry: false`
- *   full opt-out, an optional `retryTransportErrors: true` (see
- *   gmRequestWithRetry for semantics), and an optional `timeout` override
- *   (default REQUEST_TIMEOUT_MS).
+ *   full opt-out, an optional `retryWrites: true` and `retryTransportErrors:
+ *   true` (see gmRequestWithRetry for semantics), and an optional `timeout`
+ *   override (default REQUEST_TIMEOUT_MS). Only GET/HEAD are retried by
+ *   default; see SAFE_TO_RETRY_METHODS for why.
  * @param {number} [attempt] - 1-based current attempt number (internal,
  *   used for backoff calculation on recursive retries).
  * @returns {Promise<Response>} Resolves with the Response, including a
@@ -220,12 +242,13 @@ function gmRequestWithRetry(opts, attempt = 1) {
  *   timeout once retries are exhausted.
  */
 async function fetchWithRetry(url, opts = {}, attempt = 1) {
-  const { retry, retryTransportErrors = false, timeout = REQUEST_TIMEOUT_MS, ...rest } = opts;
-  const transportRetryable = (rest.method || 'GET').toUpperCase() === 'GET' || retryTransportErrors;
+  const { retry, retryWrites = false, retryTransportErrors = false, timeout = REQUEST_TIMEOUT_MS, ...rest } = opts;
+  const method = (rest.method || 'GET').toUpperCase();
+  const transportRetryable = SAFE_TO_RETRY_METHODS.includes(method) || retryWrites || retryTransportErrors;
 
   const attemptRetry = async (status, retryAfterHeader) => {
     if (retry === false || attempt >= MAX_RETRIES) return null;
-    const decision = classifyRetry({ status, attempt, retryAfterHeader });
+    const decision = classifyRetry({ status, attempt, retryAfterHeader, method, retryWrites });
     if (!decision.retryable) return null;
     dbg('http', `Retry ${attempt + 1}/${MAX_RETRIES} in ${decision.backoffMs}ms for`, url);
     await new Promise((resolve) => setTimeout(resolve, decision.backoffMs));

--- a/user.js/peeringdb-cp-consolidated-tools.user.js
+++ b/user.js/peeringdb-cp-consolidated-tools.user.js
@@ -515,6 +515,13 @@
   // Transient statuses worth retrying with backoff (rate limit / gateway).
   const RETRYABLE_STATUS = [429, 502, 503, 504];
   const MAX_RETRIES = 3;
+  // Methods a failed request may be repeated for without the repeat itself being
+  // a side effect. A 502/503/504 means the response was lost, NOT that the
+  // request was: a DELETE that committed server-side and then timed out at the
+  // gateway is indistinguishable here from one that never arrived. Replaying it
+  // re-issues a write whose outcome is unknown, so writes are excluded and must
+  // opt in per call via retryWrites: true.
+  const SAFE_TO_RETRY_METHODS = ['GET', 'HEAD'];
 
   /**
    * Returns true when diagnostics/debug mode is enabled via localStorage.
@@ -604,13 +611,23 @@
    * long. Shared by both request wrappers below so the retry policy
    * (retryable-status list, Retry-After handling, backoff curve) is defined
    * exactly once.
+   * The method is part of the decision, not just the status. Retrying a write
+   * that may already have been applied is a correctness problem, not a
+   * performance one, so only SAFE_TO_RETRY_METHODS are retried unless the caller
+   * explicitly opts in with retryWrites.
    * @param {object} params
    * @param {?number} params.status - HTTP status, or null/undefined for a network-level failure.
    * @param {number} params.attempt - 1-based current attempt number.
    * @param {?string} [params.retryAfterHeader] - Raw Retry-After header value, if any.
+   * @param {string} [params.method] - HTTP method of the request. Defaults to GET
+   *   so an omitted method is treated as the safe case it almost always is.
+   * @param {boolean} [params.retryWrites] - Opt in to retrying a non-safe method.
+   *   Only set this where re-applying the write is known to be harmless.
    * @returns {{retryable: boolean, backoffMs: number}}
    */
-  function classifyRetry({ status, attempt, retryAfterHeader }) {
+  function classifyRetry({ status, attempt, retryAfterHeader, method = 'GET', retryWrites = false }) {
+    const safeMethod = SAFE_TO_RETRY_METHODS.includes(String(method || 'GET').toUpperCase());
+    if (!safeMethod && !retryWrites) return { retryable: false, backoffMs: 0 };
     const retryable = status == null || RETRYABLE_STATUS.includes(status);
     if (!retryable) return { retryable: false, backoffMs: 0 };
     const fromHeader = parseRetryAfterMs(retryAfterHeader);
@@ -623,24 +640,28 @@
    * default timeout and retries transient failures with exponential backoff,
    * honoring a Retry-After response header when the server sends one.
    *
-   * 429/5xx responses are retried for any method. A transport-level failure
-   * (network error/timeout, as opposed to an HTTP error response) is only
-   * retried for idempotent GETs by default -- pass retryTransportErrors: true
-   * to opt in for a non-GET call known to be safe to replay. Pass retry:
-   * false to disable retries entirely for a call.
+   * Only SAFE_TO_RETRY_METHODS (GET/HEAD) are retried, for both 429/5xx
+   * responses and transport-level failures. This previously retried 429/5xx for
+   * any method, which meant a write that had already been applied server-side
+   * could be re-issued when only the response was lost. Pass retryWrites: true
+   * to opt a non-safe method back in where re-applying it is known to be
+   * harmless, retryTransportErrors: true to opt a non-safe method into
+   * transport-failure retries specifically, or retry: false to disable retries
+   * entirely for a call.
    * @param {object} opts - GM_xmlhttpRequest options, plus onload/onerror/
-   *   ontimeout callbacks, an optional `retry: false` full opt-out, and an
-   *   optional `retryTransportErrors: true`.
+   *   ontimeout callbacks, an optional `retry: false` full opt-out, an optional
+   *   `retryWrites: true`, and an optional `retryTransportErrors: true`.
    * @param {number} [attempt] - 1-based current attempt number (internal,
    *   used for backoff calculation on recursive retries).
    */
   function gmRequestWithRetry(opts, attempt = 1) {
-    const { onload, onerror, ontimeout, retry, retryTransportErrors = false, ...rest } = opts;
-    const transportRetryable = (rest.method || 'GET').toUpperCase() === 'GET' || retryTransportErrors;
+    const { onload, onerror, ontimeout, retry, retryWrites = false, retryTransportErrors = false, ...rest } = opts;
+    const method = (rest.method || 'GET').toUpperCase();
+    const transportRetryable = SAFE_TO_RETRY_METHODS.includes(method) || retryWrites || retryTransportErrors;
 
     const scheduleRetry = (status, retryAfterHeader) => {
       if (retry === false || attempt >= MAX_RETRIES) return false;
-      const decision = classifyRetry({ status, attempt, retryAfterHeader });
+      const decision = classifyRetry({ status, attempt, retryAfterHeader, method, retryWrites });
       if (!decision.retryable) return false;
       dbg('http', `Retry ${attempt + 1}/${MAX_RETRIES} in ${decision.backoffMs}ms for`, rest.url);
       setTimeout(() => gmRequestWithRetry(opts, attempt + 1), decision.backoffMs);
@@ -675,9 +696,10 @@
    * AbortController on timeout.
    * @param {string} url
    * @param {object} [opts] - fetch() init, plus an optional `retry: false`
-   *   full opt-out, an optional `retryTransportErrors: true` (see
-   *   gmRequestWithRetry for semantics), and an optional `timeout` override
-   *   (default REQUEST_TIMEOUT_MS).
+   *   full opt-out, an optional `retryWrites: true` and `retryTransportErrors:
+   *   true` (see gmRequestWithRetry for semantics), and an optional `timeout`
+   *   override (default REQUEST_TIMEOUT_MS). Only GET/HEAD are retried by
+   *   default; see SAFE_TO_RETRY_METHODS for why.
    * @param {number} [attempt] - 1-based current attempt number (internal,
    *   used for backoff calculation on recursive retries).
    * @returns {Promise<Response>} Resolves with the Response, including a
@@ -685,12 +707,13 @@
    *   timeout once retries are exhausted.
    */
   async function fetchWithRetry(url, opts = {}, attempt = 1) {
-    const { retry, retryTransportErrors = false, timeout = REQUEST_TIMEOUT_MS, ...rest } = opts;
-    const transportRetryable = (rest.method || 'GET').toUpperCase() === 'GET' || retryTransportErrors;
+    const { retry, retryWrites = false, retryTransportErrors = false, timeout = REQUEST_TIMEOUT_MS, ...rest } = opts;
+    const method = (rest.method || 'GET').toUpperCase();
+    const transportRetryable = SAFE_TO_RETRY_METHODS.includes(method) || retryWrites || retryTransportErrors;
 
     const attemptRetry = async (status, retryAfterHeader) => {
       if (retry === false || attempt >= MAX_RETRIES) return null;
-      const decision = classifyRetry({ status, attempt, retryAfterHeader });
+      const decision = classifyRetry({ status, attempt, retryAfterHeader, method, retryWrites });
       if (!decision.retryable) return null;
       dbg('http', `Retry ${attempt + 1}/${MAX_RETRIES} in ${decision.backoffMs}ms for`, url);
       await new Promise((resolve) => setTimeout(resolve, decision.backoffMs));

--- a/user.js/peeringdb-deskpro-tools.src.js
+++ b/user.js/peeringdb-deskpro-tools.src.js
@@ -3718,6 +3718,10 @@
   if (typeof window !== "undefined" && window.__PDB_TEST__) {
     window.__pdbDpTestHooks__ = {
       SCRIPT_VERSION,
+      // From lib/admincom-common.js, inlined identically into all three scripts.
+      // Exported here so the retry policy can be tested against the real shipped
+      // code rather than a re-implementation; DP is simply the smallest host.
+      fetchWithRetry,
       parsePeeringDbEntityFromHref,
       hydrateExistingPeeringDbAnchor,
       ensureOrgShortcut,

--- a/user.js/peeringdb-deskpro-tools.user.js
+++ b/user.js/peeringdb-deskpro-tools.user.js
@@ -468,6 +468,13 @@
   // Transient statuses worth retrying with backoff (rate limit / gateway).
   const RETRYABLE_STATUS = [429, 502, 503, 504];
   const MAX_RETRIES = 3;
+  // Methods a failed request may be repeated for without the repeat itself being
+  // a side effect. A 502/503/504 means the response was lost, NOT that the
+  // request was: a DELETE that committed server-side and then timed out at the
+  // gateway is indistinguishable here from one that never arrived. Replaying it
+  // re-issues a write whose outcome is unknown, so writes are excluded and must
+  // opt in per call via retryWrites: true.
+  const SAFE_TO_RETRY_METHODS = ['GET', 'HEAD'];
 
   /**
    * Returns true when diagnostics/debug mode is enabled via localStorage.
@@ -557,13 +564,23 @@
    * long. Shared by both request wrappers below so the retry policy
    * (retryable-status list, Retry-After handling, backoff curve) is defined
    * exactly once.
+   * The method is part of the decision, not just the status. Retrying a write
+   * that may already have been applied is a correctness problem, not a
+   * performance one, so only SAFE_TO_RETRY_METHODS are retried unless the caller
+   * explicitly opts in with retryWrites.
    * @param {object} params
    * @param {?number} params.status - HTTP status, or null/undefined for a network-level failure.
    * @param {number} params.attempt - 1-based current attempt number.
    * @param {?string} [params.retryAfterHeader] - Raw Retry-After header value, if any.
+   * @param {string} [params.method] - HTTP method of the request. Defaults to GET
+   *   so an omitted method is treated as the safe case it almost always is.
+   * @param {boolean} [params.retryWrites] - Opt in to retrying a non-safe method.
+   *   Only set this where re-applying the write is known to be harmless.
    * @returns {{retryable: boolean, backoffMs: number}}
    */
-  function classifyRetry({ status, attempt, retryAfterHeader }) {
+  function classifyRetry({ status, attempt, retryAfterHeader, method = 'GET', retryWrites = false }) {
+    const safeMethod = SAFE_TO_RETRY_METHODS.includes(String(method || 'GET').toUpperCase());
+    if (!safeMethod && !retryWrites) return { retryable: false, backoffMs: 0 };
     const retryable = status == null || RETRYABLE_STATUS.includes(status);
     if (!retryable) return { retryable: false, backoffMs: 0 };
     const fromHeader = parseRetryAfterMs(retryAfterHeader);
@@ -576,24 +593,28 @@
    * default timeout and retries transient failures with exponential backoff,
    * honoring a Retry-After response header when the server sends one.
    *
-   * 429/5xx responses are retried for any method. A transport-level failure
-   * (network error/timeout, as opposed to an HTTP error response) is only
-   * retried for idempotent GETs by default -- pass retryTransportErrors: true
-   * to opt in for a non-GET call known to be safe to replay. Pass retry:
-   * false to disable retries entirely for a call.
+   * Only SAFE_TO_RETRY_METHODS (GET/HEAD) are retried, for both 429/5xx
+   * responses and transport-level failures. This previously retried 429/5xx for
+   * any method, which meant a write that had already been applied server-side
+   * could be re-issued when only the response was lost. Pass retryWrites: true
+   * to opt a non-safe method back in where re-applying it is known to be
+   * harmless, retryTransportErrors: true to opt a non-safe method into
+   * transport-failure retries specifically, or retry: false to disable retries
+   * entirely for a call.
    * @param {object} opts - GM_xmlhttpRequest options, plus onload/onerror/
-   *   ontimeout callbacks, an optional `retry: false` full opt-out, and an
-   *   optional `retryTransportErrors: true`.
+   *   ontimeout callbacks, an optional `retry: false` full opt-out, an optional
+   *   `retryWrites: true`, and an optional `retryTransportErrors: true`.
    * @param {number} [attempt] - 1-based current attempt number (internal,
    *   used for backoff calculation on recursive retries).
    */
   function gmRequestWithRetry(opts, attempt = 1) {
-    const { onload, onerror, ontimeout, retry, retryTransportErrors = false, ...rest } = opts;
-    const transportRetryable = (rest.method || 'GET').toUpperCase() === 'GET' || retryTransportErrors;
+    const { onload, onerror, ontimeout, retry, retryWrites = false, retryTransportErrors = false, ...rest } = opts;
+    const method = (rest.method || 'GET').toUpperCase();
+    const transportRetryable = SAFE_TO_RETRY_METHODS.includes(method) || retryWrites || retryTransportErrors;
 
     const scheduleRetry = (status, retryAfterHeader) => {
       if (retry === false || attempt >= MAX_RETRIES) return false;
-      const decision = classifyRetry({ status, attempt, retryAfterHeader });
+      const decision = classifyRetry({ status, attempt, retryAfterHeader, method, retryWrites });
       if (!decision.retryable) return false;
       dbg('http', `Retry ${attempt + 1}/${MAX_RETRIES} in ${decision.backoffMs}ms for`, rest.url);
       setTimeout(() => gmRequestWithRetry(opts, attempt + 1), decision.backoffMs);
@@ -628,9 +649,10 @@
    * AbortController on timeout.
    * @param {string} url
    * @param {object} [opts] - fetch() init, plus an optional `retry: false`
-   *   full opt-out, an optional `retryTransportErrors: true` (see
-   *   gmRequestWithRetry for semantics), and an optional `timeout` override
-   *   (default REQUEST_TIMEOUT_MS).
+   *   full opt-out, an optional `retryWrites: true` and `retryTransportErrors:
+   *   true` (see gmRequestWithRetry for semantics), and an optional `timeout`
+   *   override (default REQUEST_TIMEOUT_MS). Only GET/HEAD are retried by
+   *   default; see SAFE_TO_RETRY_METHODS for why.
    * @param {number} [attempt] - 1-based current attempt number (internal,
    *   used for backoff calculation on recursive retries).
    * @returns {Promise<Response>} Resolves with the Response, including a
@@ -638,12 +660,13 @@
    *   timeout once retries are exhausted.
    */
   async function fetchWithRetry(url, opts = {}, attempt = 1) {
-    const { retry, retryTransportErrors = false, timeout = REQUEST_TIMEOUT_MS, ...rest } = opts;
-    const transportRetryable = (rest.method || 'GET').toUpperCase() === 'GET' || retryTransportErrors;
+    const { retry, retryWrites = false, retryTransportErrors = false, timeout = REQUEST_TIMEOUT_MS, ...rest } = opts;
+    const method = (rest.method || 'GET').toUpperCase();
+    const transportRetryable = SAFE_TO_RETRY_METHODS.includes(method) || retryWrites || retryTransportErrors;
 
     const attemptRetry = async (status, retryAfterHeader) => {
       if (retry === false || attempt >= MAX_RETRIES) return null;
-      const decision = classifyRetry({ status, attempt, retryAfterHeader });
+      const decision = classifyRetry({ status, attempt, retryAfterHeader, method, retryWrites });
       if (!decision.retryable) return null;
       dbg('http', `Retry ${attempt + 1}/${MAX_RETRIES} in ${decision.backoffMs}ms for`, url);
       await new Promise((resolve) => setTimeout(resolve, decision.backoffMs));
@@ -4097,6 +4120,10 @@
   if (typeof window !== "undefined" && window.__PDB_TEST__) {
     window.__pdbDpTestHooks__ = {
       SCRIPT_VERSION,
+      // From lib/admincom-common.js, inlined identically into all three scripts.
+      // Exported here so the retry policy can be tested against the real shipped
+      // code rather than a re-implementation; DP is simply the smallest host.
+      fetchWithRetry,
       parsePeeringDbEntityFromHref,
       hydrateExistingPeeringDbAnchor,
       ensureOrgShortcut,

--- a/user.js/peeringdb-fp-consolidated-tools.user.js
+++ b/user.js/peeringdb-fp-consolidated-tools.user.js
@@ -295,6 +295,13 @@
   // Transient statuses worth retrying with backoff (rate limit / gateway).
   const RETRYABLE_STATUS = [429, 502, 503, 504];
   const MAX_RETRIES = 3;
+  // Methods a failed request may be repeated for without the repeat itself being
+  // a side effect. A 502/503/504 means the response was lost, NOT that the
+  // request was: a DELETE that committed server-side and then timed out at the
+  // gateway is indistinguishable here from one that never arrived. Replaying it
+  // re-issues a write whose outcome is unknown, so writes are excluded and must
+  // opt in per call via retryWrites: true.
+  const SAFE_TO_RETRY_METHODS = ['GET', 'HEAD'];
 
   /**
    * Returns true when diagnostics/debug mode is enabled via localStorage.
@@ -384,13 +391,23 @@
    * long. Shared by both request wrappers below so the retry policy
    * (retryable-status list, Retry-After handling, backoff curve) is defined
    * exactly once.
+   * The method is part of the decision, not just the status. Retrying a write
+   * that may already have been applied is a correctness problem, not a
+   * performance one, so only SAFE_TO_RETRY_METHODS are retried unless the caller
+   * explicitly opts in with retryWrites.
    * @param {object} params
    * @param {?number} params.status - HTTP status, or null/undefined for a network-level failure.
    * @param {number} params.attempt - 1-based current attempt number.
    * @param {?string} [params.retryAfterHeader] - Raw Retry-After header value, if any.
+   * @param {string} [params.method] - HTTP method of the request. Defaults to GET
+   *   so an omitted method is treated as the safe case it almost always is.
+   * @param {boolean} [params.retryWrites] - Opt in to retrying a non-safe method.
+   *   Only set this where re-applying the write is known to be harmless.
    * @returns {{retryable: boolean, backoffMs: number}}
    */
-  function classifyRetry({ status, attempt, retryAfterHeader }) {
+  function classifyRetry({ status, attempt, retryAfterHeader, method = 'GET', retryWrites = false }) {
+    const safeMethod = SAFE_TO_RETRY_METHODS.includes(String(method || 'GET').toUpperCase());
+    if (!safeMethod && !retryWrites) return { retryable: false, backoffMs: 0 };
     const retryable = status == null || RETRYABLE_STATUS.includes(status);
     if (!retryable) return { retryable: false, backoffMs: 0 };
     const fromHeader = parseRetryAfterMs(retryAfterHeader);
@@ -403,24 +420,28 @@
    * default timeout and retries transient failures with exponential backoff,
    * honoring a Retry-After response header when the server sends one.
    *
-   * 429/5xx responses are retried for any method. A transport-level failure
-   * (network error/timeout, as opposed to an HTTP error response) is only
-   * retried for idempotent GETs by default -- pass retryTransportErrors: true
-   * to opt in for a non-GET call known to be safe to replay. Pass retry:
-   * false to disable retries entirely for a call.
+   * Only SAFE_TO_RETRY_METHODS (GET/HEAD) are retried, for both 429/5xx
+   * responses and transport-level failures. This previously retried 429/5xx for
+   * any method, which meant a write that had already been applied server-side
+   * could be re-issued when only the response was lost. Pass retryWrites: true
+   * to opt a non-safe method back in where re-applying it is known to be
+   * harmless, retryTransportErrors: true to opt a non-safe method into
+   * transport-failure retries specifically, or retry: false to disable retries
+   * entirely for a call.
    * @param {object} opts - GM_xmlhttpRequest options, plus onload/onerror/
-   *   ontimeout callbacks, an optional `retry: false` full opt-out, and an
-   *   optional `retryTransportErrors: true`.
+   *   ontimeout callbacks, an optional `retry: false` full opt-out, an optional
+   *   `retryWrites: true`, and an optional `retryTransportErrors: true`.
    * @param {number} [attempt] - 1-based current attempt number (internal,
    *   used for backoff calculation on recursive retries).
    */
   function gmRequestWithRetry(opts, attempt = 1) {
-    const { onload, onerror, ontimeout, retry, retryTransportErrors = false, ...rest } = opts;
-    const transportRetryable = (rest.method || 'GET').toUpperCase() === 'GET' || retryTransportErrors;
+    const { onload, onerror, ontimeout, retry, retryWrites = false, retryTransportErrors = false, ...rest } = opts;
+    const method = (rest.method || 'GET').toUpperCase();
+    const transportRetryable = SAFE_TO_RETRY_METHODS.includes(method) || retryWrites || retryTransportErrors;
 
     const scheduleRetry = (status, retryAfterHeader) => {
       if (retry === false || attempt >= MAX_RETRIES) return false;
-      const decision = classifyRetry({ status, attempt, retryAfterHeader });
+      const decision = classifyRetry({ status, attempt, retryAfterHeader, method, retryWrites });
       if (!decision.retryable) return false;
       dbg('http', `Retry ${attempt + 1}/${MAX_RETRIES} in ${decision.backoffMs}ms for`, rest.url);
       setTimeout(() => gmRequestWithRetry(opts, attempt + 1), decision.backoffMs);
@@ -455,9 +476,10 @@
    * AbortController on timeout.
    * @param {string} url
    * @param {object} [opts] - fetch() init, plus an optional `retry: false`
-   *   full opt-out, an optional `retryTransportErrors: true` (see
-   *   gmRequestWithRetry for semantics), and an optional `timeout` override
-   *   (default REQUEST_TIMEOUT_MS).
+   *   full opt-out, an optional `retryWrites: true` and `retryTransportErrors:
+   *   true` (see gmRequestWithRetry for semantics), and an optional `timeout`
+   *   override (default REQUEST_TIMEOUT_MS). Only GET/HEAD are retried by
+   *   default; see SAFE_TO_RETRY_METHODS for why.
    * @param {number} [attempt] - 1-based current attempt number (internal,
    *   used for backoff calculation on recursive retries).
    * @returns {Promise<Response>} Resolves with the Response, including a
@@ -465,12 +487,13 @@
    *   timeout once retries are exhausted.
    */
   async function fetchWithRetry(url, opts = {}, attempt = 1) {
-    const { retry, retryTransportErrors = false, timeout = REQUEST_TIMEOUT_MS, ...rest } = opts;
-    const transportRetryable = (rest.method || 'GET').toUpperCase() === 'GET' || retryTransportErrors;
+    const { retry, retryWrites = false, retryTransportErrors = false, timeout = REQUEST_TIMEOUT_MS, ...rest } = opts;
+    const method = (rest.method || 'GET').toUpperCase();
+    const transportRetryable = SAFE_TO_RETRY_METHODS.includes(method) || retryWrites || retryTransportErrors;
 
     const attemptRetry = async (status, retryAfterHeader) => {
       if (retry === false || attempt >= MAX_RETRIES) return null;
-      const decision = classifyRetry({ status, attempt, retryAfterHeader });
+      const decision = classifyRetry({ status, attempt, retryAfterHeader, method, retryWrites });
       if (!decision.retryable) return null;
       dbg('http', `Retry ${attempt + 1}/${MAX_RETRIES} in ${decision.backoffMs}ms for`, url);
       await new Promise((resolve) => setTimeout(resolve, decision.backoffMs));

--- a/user.js/tests/admincom-common-retry.test.js
+++ b/user.js/tests/admincom-common-retry.test.js
@@ -1,21 +1,50 @@
 'use strict';
 
-// Tests for the retry/backoff decision logic in lib/admincom-common.js --
-// shared by every GM_xmlhttpRequest/fetch call in all three scripts via
-// gmRequestWithRetry/fetchWithRetry. Only the pure decision functions are
-// tested directly (parseRetryAfterMs/classifyRetry); the two wrappers that
-// actually perform requests are integration-tested indirectly through the
-// CP/FP/DP fetch* functions already covered elsewhere.
+// Tests for the retry/backoff logic in lib/admincom-common.js -- shared by
+// every GM_xmlhttpRequest/fetch call in all three scripts via
+// gmRequestWithRetry/fetchWithRetry.
+//
+// The pure decision functions (parseRetryAfterMs/classifyRetry) are tested
+// directly through pure-lib-loader. fetchWithRetry needs window/fetch, so per
+// pure-lib-loader's own docs it is loaded through browser-shim instead, from a
+// generated .user.js -- which means these assertions run against the real
+// inlined code an admin installs, not a re-implementation.
+//
+// This file previously claimed the wrappers were "integration-tested
+// indirectly through the CP/FP/DP fetch* functions already covered elsewhere".
+// That was not true: no test ever returned a retryable status, and the fake
+// response had no headers.get() for fetchWithRetry to read Retry-After from,
+// so the retry path could not execute at all. It is what let writes be
+// replayed unnoticed.
 
 const { test } = require('node:test');
 const assert = require('node:assert/strict');
 const path = require('node:path');
 const { loadPureLib } = require('./helpers/pure-lib-loader');
+const { loadScript } = require('./helpers/browser-shim');
 
 const lib = loadPureLib(
   path.join(__dirname, '..', 'lib', 'admincom-common.js'),
   ['parseRetryAfterMs', 'classifyRetry'],
 );
+
+const DP_SCRIPT_PATH = path.join(__dirname, '..', 'peeringdb-deskpro-tools.user.js');
+const BUSY_URL = 'https://www.peeringdb.com/api/netixlan/7';
+
+/**
+ * Loads the real fetchWithRetry with a URL that always answers 503.
+ * Retry-After: 0 keeps the backoff at zero so the test doesn't sleep through
+ * the 1s/2s exponential curve.
+ */
+function loadBusyEndpoint() {
+  return loadScript(DP_SCRIPT_PATH, {
+    hooksKey: '__pdbDpTestHooks__',
+    pathname: '/app/ticket',
+    fetchMap: {
+      [BUSY_URL]: { __response: true, status: 503, body: {}, headers: { 'Retry-After': '0' } },
+    },
+  });
+}
 
 test('parseRetryAfterMs', async (t) => {
   await t.test('falsy input returns null', () => {
@@ -81,5 +110,72 @@ test('classifyRetry', async (t) => {
       lib.classifyRetry({ status: 429, attempt: 1, retryAfterHeader: '2' }),
       { retryable: true, backoffMs: 2000 },
     );
+  });
+});
+
+test('fetchWithRetry only replays safe methods', async (t) => {
+  await t.test('GET is retried up to MAX_RETRIES', async () => {
+    const { hooks, fetchCalls } = loadBusyEndpoint();
+    const res = await hooks.fetchWithRetry(BUSY_URL);
+    assert.equal(res.status, 503, 'the final response is still surfaced, not swallowed');
+    assert.equal(fetchCalls.length, 3, 'GET should exhaust MAX_RETRIES');
+    assert.ok(fetchCalls.every((c) => c.method === 'GET'));
+  });
+
+  // The three below are the actual defect. Each previously issued 3 requests:
+  // a 502/503/504 means the *response* was lost, not necessarily the request,
+  // so replaying a write re-applies an operation that may already have landed.
+  for (const method of ['POST', 'PUT', 'DELETE']) {
+    await t.test(`${method} is not retried`, async () => {
+      const { hooks, fetchCalls } = loadBusyEndpoint();
+      const res = await hooks.fetchWithRetry(BUSY_URL, { method });
+      assert.equal(res.status, 503);
+      assert.equal(fetchCalls.length, 1, `${method} must be issued exactly once`);
+    });
+  }
+
+  await t.test('a write can still opt in explicitly', async () => {
+    const { hooks, fetchCalls } = loadBusyEndpoint();
+    await hooks.fetchWithRetry(BUSY_URL, { method: 'DELETE', retryWrites: true });
+    assert.equal(fetchCalls.length, 3, 'retryWrites: true restores the old behavior on request');
+  });
+
+  await t.test('retry: false still disables retries for a GET', async () => {
+    const { hooks, fetchCalls } = loadBusyEndpoint();
+    await hooks.fetchWithRetry(BUSY_URL, { retry: false });
+    assert.equal(fetchCalls.length, 1);
+  });
+
+  await t.test('a non-retryable status is returned immediately for any method', async () => {
+    const { hooks, fetchCalls } = loadScript(DP_SCRIPT_PATH, {
+      hooksKey: '__pdbDpTestHooks__',
+      pathname: '/app/ticket',
+      fetchMap: { [BUSY_URL]: { __response: true, status: 404, body: {} } },
+    });
+    const res = await hooks.fetchWithRetry(BUSY_URL);
+    assert.equal(res.status, 404);
+    assert.equal(fetchCalls.length, 1, '404 is not in RETRYABLE_STATUS');
+  });
+});
+
+test('classifyRetry refuses non-safe methods unless opted in', async (t) => {
+  await t.test('safe methods stay retryable', () => {
+    assert.equal(lib.classifyRetry({ status: 503, attempt: 1, method: 'GET' }).retryable, true);
+    assert.equal(lib.classifyRetry({ status: 503, attempt: 1, method: 'HEAD' }).retryable, true);
+    assert.equal(lib.classifyRetry({ status: 503, attempt: 1, method: 'get' }).retryable, true, 'case-insensitive');
+  });
+
+  await t.test('writes are refused', () => {
+    for (const method of ['POST', 'PUT', 'DELETE', 'PATCH']) {
+      assert.equal(lib.classifyRetry({ status: 503, attempt: 1, method }).retryable, false, method);
+    }
+  });
+
+  await t.test('retryWrites opts a write back in', () => {
+    assert.equal(lib.classifyRetry({ status: 503, attempt: 1, method: 'DELETE', retryWrites: true }).retryable, true);
+  });
+
+  await t.test('an omitted method is treated as GET', () => {
+    assert.equal(lib.classifyRetry({ status: 503, attempt: 1 }).retryable, true);
   });
 });


### PR DESCRIPTION
The retry wrappers replayed 429/502/503/504 responses for any HTTP method.
This was deliberate and documented -- gmRequestWithRetry's docblock said
"429/5xx responses are retried for any method" -- but the policy is unsafe.
Those statuses mean the *response* was lost, not that the request was: a
DELETE that committed server-side and then timed out at the gateway is
indistinguishable here from one that never arrived. Replaying it re-issues
a write whose outcome is unknown.

Measured against a constant 503, GET, POST, PUT and DELETE each issued 3
requests. FP's IX-F resolve (PUT) and remove (DELETE) both went through
this path and neither passed retry: false. CP avoided it only by accident:
pdbPost derives allowRetry from PDB_API_RETRIES = 1, so raising that one
constant would have armed every CP DELETE.

The method gate already existed but guarded only the transport-error
branch; the retryable-status branch called classifyRetry, which took no
method at all. Making the method part of the decision puts both branches
under one rule.

Changes:
- Added SAFE_TO_RETRY_METHODS (GET, HEAD) beside the other retry-policy
  constants, with the reasoning inline.
- classifyRetry now takes method (defaulting to GET) and retryWrites, and
  refuses non-safe methods before considering the status.
- Both wrappers pass method/retryWrites through, so GM_xmlhttpRequest and
  fetch behave identically.
- Added a retryWrites: true opt-in for callers where re-applying a write is
  known to be harmless. No current caller uses it.
- Exported fetchWithRetry on DP's test hooks so the policy can be asserted
  against the real inlined code rather than a re-implementation.

Security:
- Removes silent duplicate writes against an already-degraded server. The
  worst case was a DELETE reported as failed to the admin after it had
  actually succeeded, and a duplicated Request-IXF-Import POST.
- Fails closed: a transient 503 on a write now surfaces to the admin, who
  retries deliberately, instead of the script deciding for them.

Testing:
- node --test from user.js/: 493 tests, 492 pass, 1 skipped (live tests are
  opt-in), up from 480/479.
- Added wrapper tests asserting POST/PUT/DELETE issue exactly 1 request
  against a constant 503, and GET exactly 3. The GET assertion is the one
  that matters: without it a broken fixture yields a vacuously green "no
  retry happened".
- Also covered: retryWrites restores replay on request, retry: false still
  works, and a 404 short-circuits for any method.
- Confirmed not vacuous: removing the method gate fails 6 of the new cases.
- Corrected this file's header comment, which claimed the wrappers were
  "integration-tested indirectly ... elsewhere". They were not, and could
  not be -- no fixture returned a retryable status.

Backwards Compatibility:
- GET/HEAD behavior is unchanged, which is the overwhelming majority of
  traffic in all three scripts.
- Write behavior changes by design. No caller passes retryWrites or
  retryTransportErrors today, so every existing write now attempts once.
- classifyRetry's method parameter defaults to GET, so its existing callers
  and tests are unaffected.

Assisted-by: Claude:claude-opus-5

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>