### PR TITLE
fix(cp): bound and anchor the name-normalization rules

### DIFF
--- a/user.js/lib/cp-name-normalization.js
+++ b/user.js/lib/cp-name-normalization.js
@@ -35,6 +35,29 @@ function hasBalancedParens(value) {
   return depth === 0;
 }
 
+// Upper bound on names this module will attempt to normalize. See the note in
+// stripCompanyTypeSuffix: the legal-form patterns backtrack quadratically, and
+// RDAP supplies these strings.
+const MAX_NORMALIZABLE_NAME_LENGTH = 200;
+
+// Names preserved verbatim because a legal-form pattern would otherwise eat
+// part of the brand.
+const KNOWN_INTACT_NAMES = new Set(["trade me"]);
+
+/**
+ * Reports whether a name must be preserved verbatim rather than suffix-stripped.
+ * Purpose: Share one false-positive list between the pre-check and the strip
+ * loop, so a guarded name stays guarded at every intermediate step.
+ * Necessity: The loop rewrites `candidate` in place; a guard that only inspects
+ * the original input silently stops applying after the first strip.
+ * @ai Keep behavior stable and prefer minimal, localized edits.
+ * @param {string} value - Candidate name at any point during stripping.
+ * @returns {boolean} True when the name is a known false positive.
+ */
+function isKnownIntactName(value) {
+  return KNOWN_INTACT_NAMES.has(String(value || "").trim().toLowerCase());
+}
+
 /**
  * Strips leading and trailing legal company-type prefixes and suffixes from a name.
  * Purpose: Keep network short Name concise while preserving full legal form
@@ -49,8 +72,20 @@ function stripCompanyTypeSuffix(name) {
   const original = String(name || "").trim().replace(/\s+/g, " ");
   if (!original) return "";
 
-  // Known false positive: keep brand name intact (do not strip trailing "ME").
-  if (original === "Trade Me") return original;
+  // Several patterns below pair a lazy `(.*?)` with a separator character class,
+  // which backtracks quadratically when the rest of the pattern cannot match.
+  // Measured on a separator-dense string: 800 chars ~ 210ms, 3200 ~ 460ms,
+  // 6400 ~ 1.9s -- enough to freeze the tab. Names reach this function straight
+  // from third-party RDAP records, so the length is not ours to trust. No real
+  // legal name approaches this bound, and returning the input unchanged is the
+  // right outcome for something this long anyway.
+  if (original.length > MAX_NORMALIZABLE_NAME_LENGTH) return original;
+
+  // Known false positives: names whose tail looks like a legal suffix but isn't
+  // (here "Me" parses as Brazil's ME/Microempresa). Also re-checked inside the
+  // strip loop -- checking only the input meant the guard held for "Trade Me"
+  // but not "Trade Me Limited", which stripped through to "Trade".
+  if (isKnownIntactName(original)) return original;
 
   const legalSuffixPatterns = [
     "Corporation", // Corporation (US and other common-law jurisdictions)
@@ -283,6 +318,9 @@ function stripCompanyTypeSuffix(name) {
 
   // Strip trailing suffixes (may be multiple layers)
   while (candidate && candidate !== previous && suffixRegex.test(candidate)) {
+    // Re-check every layer: "Trade Me Limited" reaches "Trade Me" here, and
+    // without this the next pass strips "Me" as a Brazilian ME suffix.
+    if (isKnownIntactName(candidate)) break;
     previous = candidate;
     const stripped = candidate.replace(suffixRegex, "").trim().replace(/[\s,().-]+$/g, "").trim();
     // Reject a strip that orphans a real "(" that was balanced before this step --
@@ -696,10 +734,16 @@ function sanitizeRdapOrgName(name) {
     candidate = collapsedLegalAlias;
   }
 
-  // Extract text after trading-as patterns if present.
-  const tradingAsMatch = candidate.match(/(?:trading\s+as|t\s*\/\s*a|d\s*\/?\s*b\s*\/?\s*a|dba)\s+(.+)$/i);
+  // Extract text after trading-as patterns if present. Anchored, and requiring a
+  // person/legal part before the marker, exactly like the twin in
+  // parseRdapTradingAsIdentity below. Unanchored, the marker matched anywhere in
+  // the string: "DBA Systems Inc" became "Systems Inc" and "Sundba Media Group"
+  // became "Media Group", both from a mid-word or leading "dba".
+  const tradingAsMatch = candidate.match(
+    /^(.+?)\s+(?:trading\s+as|t\s*\/\s*a|d\s*\/?\s*b\s*\/?\s*a|dba)\s+(.+)$/i,
+  );
   if (tradingAsMatch) {
-    const extracted = tradingAsMatch[1].trim();
+    const extracted = tradingAsMatch[2].trim();
     // Use the extraction if it's substantially longer than or similar to the person part (avoid picking the person name)
     if (extracted.length >= 5) {
       candidate = extracted;
@@ -758,7 +802,12 @@ function parsePolishScPartnerIdentity(name) {
   if (!original) return { name: "", knownAs: "" };
 
   const base = original.replace(/^(.+?)\s*,\s*remarks\s*:.*/i, "$1").trim();
-  const match = base.match(/^(.*?\bS\.?\s*C\.?)\s+(.+)$/i);
+  // The company part is required (`.+?\s+`), not optional. With `.*?` a *leading*
+  // S.C. matched with nothing before it, so the Romanian "Societate Comerciala"
+  // prefix in "S.C. Digital Cable Systems Romania SRL" parsed as a Polish civil
+  // partnership and the name collapsed to "S.C" -- the partner-tail heuristic
+  // below waves it through, because that tail does carry two Capitalized pairs.
+  const match = base.match(/^(.+?\s+S\.?\s*C\.?)\s+(.+)$/i);
   if (!match) {
     return { name: sanitizeRdapOrgName(original), knownAs: "" };
   }

--- a/user.js/peeringdb-cp-consolidated-tools.user.js
+++ b/user.js/peeringdb-cp-consolidated-tools.user.js
@@ -2254,6 +2254,29 @@
     return depth === 0;
   }
 
+  // Upper bound on names this module will attempt to normalize. See the note in
+  // stripCompanyTypeSuffix: the legal-form patterns backtrack quadratically, and
+  // RDAP supplies these strings.
+  const MAX_NORMALIZABLE_NAME_LENGTH = 200;
+
+  // Names preserved verbatim because a legal-form pattern would otherwise eat
+  // part of the brand.
+  const KNOWN_INTACT_NAMES = new Set(["trade me"]);
+
+  /**
+   * Reports whether a name must be preserved verbatim rather than suffix-stripped.
+   * Purpose: Share one false-positive list between the pre-check and the strip
+   * loop, so a guarded name stays guarded at every intermediate step.
+   * Necessity: The loop rewrites `candidate` in place; a guard that only inspects
+   * the original input silently stops applying after the first strip.
+   * @ai Keep behavior stable and prefer minimal, localized edits.
+   * @param {string} value - Candidate name at any point during stripping.
+   * @returns {boolean} True when the name is a known false positive.
+   */
+  function isKnownIntactName(value) {
+    return KNOWN_INTACT_NAMES.has(String(value || "").trim().toLowerCase());
+  }
+
   /**
    * Strips leading and trailing legal company-type prefixes and suffixes from a name.
    * Purpose: Keep network short Name concise while preserving full legal form
@@ -2268,8 +2291,20 @@
     const original = String(name || "").trim().replace(/\s+/g, " ");
     if (!original) return "";
 
-    // Known false positive: keep brand name intact (do not strip trailing "ME").
-    if (original === "Trade Me") return original;
+    // Several patterns below pair a lazy `(.*?)` with a separator character class,
+    // which backtracks quadratically when the rest of the pattern cannot match.
+    // Measured on a separator-dense string: 800 chars ~ 210ms, 3200 ~ 460ms,
+    // 6400 ~ 1.9s -- enough to freeze the tab. Names reach this function straight
+    // from third-party RDAP records, so the length is not ours to trust. No real
+    // legal name approaches this bound, and returning the input unchanged is the
+    // right outcome for something this long anyway.
+    if (original.length > MAX_NORMALIZABLE_NAME_LENGTH) return original;
+
+    // Known false positives: names whose tail looks like a legal suffix but isn't
+    // (here "Me" parses as Brazil's ME/Microempresa). Also re-checked inside the
+    // strip loop -- checking only the input meant the guard held for "Trade Me"
+    // but not "Trade Me Limited", which stripped through to "Trade".
+    if (isKnownIntactName(original)) return original;
 
     const legalSuffixPatterns = [
       "Corporation", // Corporation (US and other common-law jurisdictions)
@@ -2502,6 +2537,9 @@
 
     // Strip trailing suffixes (may be multiple layers)
     while (candidate && candidate !== previous && suffixRegex.test(candidate)) {
+      // Re-check every layer: "Trade Me Limited" reaches "Trade Me" here, and
+      // without this the next pass strips "Me" as a Brazilian ME suffix.
+      if (isKnownIntactName(candidate)) break;
       previous = candidate;
       const stripped = candidate.replace(suffixRegex, "").trim().replace(/[\s,().-]+$/g, "").trim();
       // Reject a strip that orphans a real "(" that was balanced before this step --
@@ -2915,10 +2953,16 @@
       candidate = collapsedLegalAlias;
     }
 
-    // Extract text after trading-as patterns if present.
-    const tradingAsMatch = candidate.match(/(?:trading\s+as|t\s*\/\s*a|d\s*\/?\s*b\s*\/?\s*a|dba)\s+(.+)$/i);
+    // Extract text after trading-as patterns if present. Anchored, and requiring a
+    // person/legal part before the marker, exactly like the twin in
+    // parseRdapTradingAsIdentity below. Unanchored, the marker matched anywhere in
+    // the string: "DBA Systems Inc" became "Systems Inc" and "Sundba Media Group"
+    // became "Media Group", both from a mid-word or leading "dba".
+    const tradingAsMatch = candidate.match(
+      /^(.+?)\s+(?:trading\s+as|t\s*\/\s*a|d\s*\/?\s*b\s*\/?\s*a|dba)\s+(.+)$/i,
+    );
     if (tradingAsMatch) {
-      const extracted = tradingAsMatch[1].trim();
+      const extracted = tradingAsMatch[2].trim();
       // Use the extraction if it's substantially longer than or similar to the person part (avoid picking the person name)
       if (extracted.length >= 5) {
         candidate = extracted;
@@ -2977,7 +3021,12 @@
     if (!original) return { name: "", knownAs: "" };
 
     const base = original.replace(/^(.+?)\s*,\s*remarks\s*:.*/i, "$1").trim();
-    const match = base.match(/^(.*?\bS\.?\s*C\.?)\s+(.+)$/i);
+    // The company part is required (`.+?\s+`), not optional. With `.*?` a *leading*
+    // S.C. matched with nothing before it, so the Romanian "Societate Comerciala"
+    // prefix in "S.C. Digital Cable Systems Romania SRL" parsed as a Polish civil
+    // partnership and the name collapsed to "S.C" -- the partner-tail heuristic
+    // below waves it through, because that tail does carry two Capitalized pairs.
+    const match = base.match(/^(.+?\s+S\.?\s*C\.?)\s+(.+)$/i);
     if (!match) {
       return { name: sanitizeRdapOrgName(original), knownAs: "" };
     }

--- a/user.js/tests/cp-name-normalization.test.js
+++ b/user.js/tests/cp-name-normalization.test.js
@@ -57,6 +57,38 @@ test('stripCompanyTypeSuffix', async (t) => {
     assert.equal(lib.stripCompanyTypeSuffix('Trade Me'), 'Trade Me');
   });
 
+  await t.test('the "Trade Me" exception survives an outer legal suffix', () => {
+    // Regression: the guard used to compare the *input* only, so it held for
+    // the bare name and evaporated on the commoner registered form -- the
+    // first pass stripped "Limited" and the second ate "Me" as Brazil's ME.
+    assert.equal(lib.stripCompanyTypeSuffix('Trade Me Limited'), 'Trade Me');
+    assert.equal(lib.stripCompanyTypeSuffix('Trade Me Ltd.'), 'Trade Me');
+  });
+
+  await t.test('a pathologically long name returns immediately, unchanged', () => {
+    // Regression: several patterns here pair a lazy group with a separator
+    // class and backtrack quadratically -- a separator-dense 6400-char name
+    // measured ~1.9s, and these strings arrive verbatim from third-party
+    // RDAP records. Timing is asserted loosely (a 200x margin over the
+    // measured cost) so this fails on a reintroduced blowup, not on a slow
+    // CI runner.
+    const pathological = 'A.-, '.repeat(4000); // 20,000 chars
+    const started = Date.now();
+    assert.equal(lib.stripCompanyTypeSuffix(pathological), pathological.trim());
+    assert.ok(
+      Date.now() - started < 200,
+      `stripCompanyTypeSuffix took ${Date.now() - started}ms on a 20k-char name`,
+    );
+  });
+
+  await t.test('the length guard does not disturb realistic names', () => {
+    // 200 chars is far above any real legal name; confirm a long-but-plausible
+    // one still normalizes rather than being waved through by the guard.
+    const longButReal = `${'Global Interconnection Services '.repeat(4).trim()} GmbH`;
+    assert.ok(longButReal.length < 200);
+    assert.equal(lib.stripCompanyTypeSuffix(longButReal).endsWith('GmbH'), false);
+  });
+
   await t.test('ASCII-transliterated Turkish "Limited Sirketi" is recognized', () => {
     assert.equal(
       lib.stripCompanyTypeSuffix('AnatoliaCore Teknoloji Limited Sirketi'),
@@ -191,6 +223,32 @@ test('parsePolishScPartnerIdentity splits company/partner tail', () => {
   const result = lib.parsePolishScPartnerIdentity('NET-KONT@KT S.C. Dariusz Koper Andrzej Nowak');
   assert.equal(result.name, 'NET-KONT@KT S.C');
   assert.equal(result.knownAs, 'Dariusz Koper Andrzej Nowak');
+});
+
+test('sanitizeRdapOrgName only honors an anchored trading-as marker', () => {
+  // Regression: the extraction regex was unanchored, so "dba" matched at the
+  // start of a string or in the middle of a word and the org name lost
+  // everything before it. The anchored form below mirrors the correct twin in
+  // parseRdapTradingAsIdentity.
+  assert.equal(lib.sanitizeRdapOrgName('DBA Systems Inc'), 'DBA Systems Inc');
+  assert.equal(lib.sanitizeRdapOrgName('Sundba Media Group'), 'Sundba Media Group');
+  assert.equal(lib.sanitizeRdapOrgName('T/A Networks Limited'), 'T/A Networks Limited');
+  // A genuine trading-as name must still resolve to the trading name.
+  assert.equal(lib.sanitizeRdapOrgName('Remzi Toker trading as VENTURESDC'), 'VENTURESDC');
+  assert.equal(lib.sanitizeRdapOrgName('Jane Roe dba Acme Networks'), 'Acme Networks');
+});
+
+test('parsePolishScPartnerIdentity requires a company before the S.C. marker', () => {
+  // Regression: a lazy leading group let a *prefix* S.C. match with nothing
+  // before it, so Romania's "Societate Comerciala" prefix was read as a Polish
+  // civil partnership and the whole name collapsed to "S.C".
+  const romanian = lib.parsePolishScPartnerIdentity('S.C. Digital Cable Systems Romania SRL');
+  assert.equal(romanian.name, 'S.C. Digital Cable Systems Romania SRL');
+  assert.equal(romanian.knownAs, '');
+
+  // Same input through the dispatcher that CP actually calls.
+  const viaDispatcher = lib.parseOrganizationNameIdentity('S.C. Digital Cable Systems Romania SRL');
+  assert.equal(viaDispatcher.name, 'S.C. Digital Cable Systems Romania SRL');
 });
 
 test('looksLikePersonalNameShape', () => {


### PR DESCRIPTION
Four defects in lib/cp-name-normalization.js let third-party RDAP strings
either freeze the tab or silently corrupt an organization name that an
admin then approves. All four were reproduced by execution before being
fixed, and each guard was proven to fail without its fix.

A separator-dense name backtracks quadratically through the legal-form
patterns -- 6,400 characters measured about 1.9 seconds, 20,000 took 20.
Two other rules matched in the wrong place: the trading-as extraction was
unanchored, so "DBA Systems Inc" became "Systems Inc" and "Sundba Media
Group" became "Media Group"; and the Polish civil-partnership rule let a
*leading* S.C. match with nothing before it, so Romania's "Societate
Comerciala" prefix collapsed "S.C. Digital Cable Systems Romania SRL" to
"S.C". The "Trade Me" false-positive guard compared the function's input
rather than the working candidate, so it held for the bare brand and
evaporated on the commoner registered form, leaving "Trade".

Changes:
- Add MAX_NORMALIZABLE_NAME_LENGTH (200) and return early from
  stripCompanyTypeSuffix above it. The quadratic patterns remain but are
  unreachable with a pathological input; rewriting 150+ jurisdiction
  patterns would risk exactly the silent regressions this module's
  characterization suite exists to catch.
- Extract the false-positive list into KNOWN_INTACT_NAMES plus an
  isKnownIntactName() helper, and consult it on every pass of the
  suffix-strip loop rather than once on the input.
- Anchor sanitizeRdapOrgName's trading-as regex and take its second
  group, matching the already-correct twin in parseRdapTradingAsIdentity
  instead of keeping a second, divergent copy.
- Require a company part before the marker in parsePolishScPartnerIdentity
  (`.+?\s+S.C.` rather than `.*?\bS.C.`).

Security:
- Removes a denial-of-service reachable from unvalidated third-party RDAP
  data: a long org name froze the admin's tab for seconds per call.
- The two anchoring fixes remove silent data corruption on a path whose
  output an admin approves into PeeringDB; a truncated or mis-split legal
  name previously looked like a legitimate normalization result.

Testing:
- node --test: 505 tests, 504 pass, 1 skipped (live tests are opt-in).
- Five new cases in tests/cp-name-normalization.test.js covering all four
  defects plus the inputs that must keep working: the genuine Polish
  "NET-KONT@KT S.C." split, a real "trading as" extraction, and a
  long-but-plausible name that must still normalize.
- Each fix reverted individually and confirmed red: the length guard
  (20s, then failure), the per-layer Trade Me guard, the anchored
  trading-as regex, and the required S.C. company part.
- build_userscripts.py regenerated CP and reports up to date; all three
  .user.js pass node --check.

Backwards Compatibility:
- No API or storage changes. Behavior changes only for inputs that were
  previously mishandled; the existing characterization suite, which locks
  in current output for every other shape, is unchanged and still green.

Assisted-by: Claude:claude-opus-5

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>