### PR TITLE
fix(cp): cancel in-flight work when a modal is dismissed

### DIFF
--- a/user.js/peeringdb-cp-consolidated-tools.src.js
+++ b/user.js/peeringdb-cp-consolidated-tools.src.js
@@ -2622,10 +2622,27 @@
     backdrop.appendChild(modal);
     document.body.appendChild(backdrop);
 
+    // Resolves when the modal is dismissed. The opener awaits this, so the
+    // caller's action lock spans the modal's lifetime rather than only its
+    // first render -- otherwise a second click stacks a second modal, with its
+    // own cancelSignal, over rows the first one is still writing.
+    let resolveClosed;
+    const closed = new Promise((resolve) => { resolveClosed = resolve; });
+
     /**
-     * Removes the modal from the DOM.
+     * Removes the modal from the DOM and cancels any apply loop in flight.
+     * @ai Preserve the cancelSignal write and the resolveClosed() call.
      */
-    function close() { backdrop.remove(); }
+    function close() {
+      // Dismissing the UI must stop the work, not just hide it. This was
+      // `backdrop.remove()` alone, so a backdrop click mid-apply tore down the
+      // progress display while the loop kept issuing PUT/DELETE with no
+      // remaining way to abort. The explicit Cancel button already set this
+      // flag; close() did not.
+      cancelSignal.cancelled = true;
+      backdrop.remove();
+      resolveClosed();
+    }
     closeBtn.addEventListener("click", close);
     backdrop.addEventListener("click", (ev) => { if (ev.target === backdrop) close(); });
 
@@ -2762,11 +2779,17 @@
       const conflictItems = collectConflictItemsFromEntries(entries);
       if (conflictItems.length === 0) return;
       if (!selectedIxlanId) { status.textContent = "Select an ixlan first."; return; }
+      // Fire-and-forget: nothing awaits this, so it needs its own handler --
+      // see "Fire-and-forget async work must carry its own try/catch" in
+      // docs/CONVENTIONS.md. It now settles on dismissal, not on first render.
       openConflictResolverModal({
         ixlanId: String(selectedIxlanId),
         ticketId: payload.ticketId || "",
         payload,
         conflictItems,
+      }).catch((error) => {
+        console.error(`[${MODULE_PREFIX}] Conflict resolver modal failed`, error);
+        status.textContent = "Conflict resolver failed. See console for details.";
       });
     });
     conflictsBannerBtn.addEventListener("click", () => resolveConflictsBtn.click());
@@ -2774,7 +2797,10 @@
     recentChangesBtn.addEventListener("click", () => {
       if (!isFeatureEnabled("recentIpChanges")) { status.textContent = "Recent IP changes feature is disabled."; return; }
       if (!selectedIxlanId) { status.textContent = "Select an ixlan first."; return; }
-      openRecentIpChangesModal(String(selectedIxlanId));
+      // Fire-and-forget, so it carries its own handler (docs/CONVENTIONS.md).
+      openRecentIpChangesModal(String(selectedIxlanId)).catch((error) => {
+        console.error(`[${MODULE_PREFIX}] Recent IP changes modal failed`, error);
+      });
     });
 
     dryBtn.addEventListener("click", () => { refresh(); });
@@ -2827,6 +2853,10 @@
     });
 
     await refresh();
+    // Resolve only once the admin dismisses the modal. The toolbar handler
+    // holds its action lock across this await, so a second click reports
+    // "already running" instead of stacking a second modal over the same rows.
+    await closed;
   }
 
   // ── IX-F Member Audit (helpers) ────────────────────────────────────────────
@@ -3321,7 +3351,10 @@
     setIconButtonLabel(recentChangesBtn, "\u23f2", `Recent IP changes (\u2264${RECENT_IP_CHANGES_WINDOW_MIN}m)`);
     recentChangesBtn.addEventListener("click", () => {
       if (!isFeatureEnabled("recentIpChanges")) return;
-      openRecentIpChangesModal(String(ixlanId));
+      // Fire-and-forget, so it carries its own handler (docs/CONVENTIONS.md).
+      openRecentIpChangesModal(String(ixlanId)).catch((error) => {
+        console.error(`[${MODULE_PREFIX}] Recent IP changes modal failed`, error);
+      });
     });
     // Right-aligned fixed-offset strip: buttons stay side-by-side.
     buttons.append(closeBtn, refreshBtn, recentChangesBtn, cancelApplyBtn, applyBtn);
@@ -3329,8 +3362,27 @@
     backdrop.appendChild(modal);
     document.body.appendChild(backdrop);
 
-    /** Removes the modal. */
-    function close() { backdrop.remove(); }
+    // Resolves when the modal is dismissed. The opener awaits this, so the
+    // caller's action lock spans the modal's lifetime rather than only its
+    // first render -- otherwise a second click stacks a second modal, with its
+    // own cancelSignal, over rows the first one is still writing.
+    let resolveClosed;
+    const closed = new Promise((resolve) => { resolveClosed = resolve; });
+
+    /**
+     * Removes the modal and cancels any merge loop in flight.
+     * @ai Preserve the cancelSignal write and the resolveClosed() call.
+     */
+    function close() {
+      // Dismissing the UI must stop the work, not just hide it. This was
+      // `backdrop.remove()` alone, so a backdrop click mid-apply tore down the
+      // progress display while the loop kept issuing PUT/DELETE with no
+      // remaining way to abort. The explicit Cancel button already set this
+      // flag; close() did not.
+      cancelSignal.cancelled = true;
+      backdrop.remove();
+      resolveClosed();
+    }
     closeBtn.addEventListener("click", close);
     backdrop.addEventListener("click", (ev) => { if (ev.target === backdrop) close(); });
 
@@ -3430,6 +3482,10 @@
     });
 
     await refresh();
+    // Resolve only once the admin dismisses the modal. The toolbar handler
+    // holds its action lock across this await, so a second click reports
+    // "already running" instead of stacking a second modal over the same rows.
+    await closed;
   }
 
   // ── IXLAN Conflict Resolver (helpers) ──────────────────────────────────────
@@ -4039,11 +4095,14 @@
     confirmLabel.textContent = `Type ixlan id "${ixlanId}" to enable Apply: `;
     const confirmInput = document.createElement("input");
     confirmInput.type = "text";
-    confirmInput.placeholder = normalizedExpectedIxlanId || ixlanId;
-    // Pre-fill to prevent false lockout where the operator sees "3990"
-    // but Apply remains disabled due placeholder/value confusion.
-    // Final window.confirm remains in place as destructive safeguard.
-    confirmInput.value = normalizedExpectedIxlanId;
+    // Deliberately NOT the expected id: a placeholder showing "3990" made an
+    // empty field look filled, which is the "false lockout" the previous
+    // pre-fill was added to work around. That pre-fill satisfied the gate from
+    // first render, so the banner's "type the ixlan id to enable Apply" was
+    // never actually enforced. Fix the confusing placeholder instead and leave
+    // the field empty, so the admin's keystrokes are what enable Apply.
+    // @ai Do NOT set confirmInput.value here.
+    confirmInput.placeholder = "ixlan id";
     Object.assign(confirmInput.style, { padding: "4px 6px", marginLeft: "6px", width: "100px" });
     confirmLabel.appendChild(confirmInput);
     confirmRow.appendChild(confirmLabel);
@@ -4125,7 +4184,25 @@
     backdrop.appendChild(modal);
     document.body.appendChild(backdrop);
 
-    closeBtn.addEventListener("click", () => backdrop.remove());
+    // See the same pattern in openIxlanRenumberModal: resolves on dismissal so
+    // the enclosing action lock covers the modal's whole lifetime.
+    let resolveClosed;
+    const closed = new Promise((resolve) => { resolveClosed = resolve; });
+
+    /**
+     * Removes the modal and cancels any delete loop in flight.
+     * @ai Preserve the cancelSignal write and the resolveClosed() call.
+     */
+    function close() {
+      // Dismissing the UI must stop the work, not just hide it -- this modal
+      // issues DELETEs, and the teardown used to leave the loop running with
+      // no progress display and no way to abort.
+      cancelSignal.cancelled = true;
+      backdrop.remove();
+      resolveClosed();
+    }
+    closeBtn.addEventListener("click", close);
+    backdrop.addEventListener("click", (ev) => { if (ev.target === backdrop) close(); });
 
     // State.
     let items = initialItems.map((it) => ({
@@ -4354,6 +4431,10 @@
     });
 
     await refresh();
+    // Resolve only once the admin dismisses the modal. The toolbar handler
+    // holds its action lock across this await, so a second click reports
+    // "already running" instead of stacking a second modal over the same rows.
+    await closed;
   }
 
   // ── Recent IP Changes Audit Report (helpers) ───────────────────────────────
@@ -4791,7 +4872,19 @@
     backdrop.appendChild(modal);
     document.body.appendChild(backdrop);
 
-    closeBtn.addEventListener("click", () => backdrop.remove());
+    // Read-only report, so there is no cancelSignal to trip -- but the opener
+    // still awaits dismissal, which is what makes the caller's "report is
+    // already open" lock message true rather than aspirational.
+    let resolveClosed;
+    const closed = new Promise((resolve) => { resolveClosed = resolve; });
+
+    /** Removes the modal. */
+    function close() {
+      backdrop.remove();
+      resolveClosed();
+    }
+    closeBtn.addEventListener("click", close);
+    backdrop.addEventListener("click", (ev) => { if (ev.target === backdrop) close(); });
 
     async function refresh() {
       refreshBtn.disabled = true; copyBtn.disabled = true;
@@ -4819,6 +4912,10 @@
     });
 
     await refresh();
+    // Resolve only once the admin dismisses the modal. The toolbar handler
+    // holds its action lock across this await, so a second click reports
+    // "already running" instead of stacking a second modal over the same rows.
+    await closed;
   }
 
   /**

--- a/user.js/peeringdb-cp-consolidated-tools.user.js
+++ b/user.js/peeringdb-cp-consolidated-tools.user.js
@@ -4009,10 +4009,27 @@
     backdrop.appendChild(modal);
     document.body.appendChild(backdrop);
 
+    // Resolves when the modal is dismissed. The opener awaits this, so the
+    // caller's action lock spans the modal's lifetime rather than only its
+    // first render -- otherwise a second click stacks a second modal, with its
+    // own cancelSignal, over rows the first one is still writing.
+    let resolveClosed;
+    const closed = new Promise((resolve) => { resolveClosed = resolve; });
+
     /**
-     * Removes the modal from the DOM.
+     * Removes the modal from the DOM and cancels any apply loop in flight.
+     * @ai Preserve the cancelSignal write and the resolveClosed() call.
      */
-    function close() { backdrop.remove(); }
+    function close() {
+      // Dismissing the UI must stop the work, not just hide it. This was
+      // `backdrop.remove()` alone, so a backdrop click mid-apply tore down the
+      // progress display while the loop kept issuing PUT/DELETE with no
+      // remaining way to abort. The explicit Cancel button already set this
+      // flag; close() did not.
+      cancelSignal.cancelled = true;
+      backdrop.remove();
+      resolveClosed();
+    }
     closeBtn.addEventListener("click", close);
     backdrop.addEventListener("click", (ev) => { if (ev.target === backdrop) close(); });
 
@@ -4149,11 +4166,17 @@
       const conflictItems = collectConflictItemsFromEntries(entries);
       if (conflictItems.length === 0) return;
       if (!selectedIxlanId) { status.textContent = "Select an ixlan first."; return; }
+      // Fire-and-forget: nothing awaits this, so it needs its own handler --
+      // see "Fire-and-forget async work must carry its own try/catch" in
+      // docs/CONVENTIONS.md. It now settles on dismissal, not on first render.
       openConflictResolverModal({
         ixlanId: String(selectedIxlanId),
         ticketId: payload.ticketId || "",
         payload,
         conflictItems,
+      }).catch((error) => {
+        console.error(`[${MODULE_PREFIX}] Conflict resolver modal failed`, error);
+        status.textContent = "Conflict resolver failed. See console for details.";
       });
     });
     conflictsBannerBtn.addEventListener("click", () => resolveConflictsBtn.click());
@@ -4161,7 +4184,10 @@
     recentChangesBtn.addEventListener("click", () => {
       if (!isFeatureEnabled("recentIpChanges")) { status.textContent = "Recent IP changes feature is disabled."; return; }
       if (!selectedIxlanId) { status.textContent = "Select an ixlan first."; return; }
-      openRecentIpChangesModal(String(selectedIxlanId));
+      // Fire-and-forget, so it carries its own handler (docs/CONVENTIONS.md).
+      openRecentIpChangesModal(String(selectedIxlanId)).catch((error) => {
+        console.error(`[${MODULE_PREFIX}] Recent IP changes modal failed`, error);
+      });
     });
 
     dryBtn.addEventListener("click", () => { refresh(); });
@@ -4214,6 +4240,10 @@
     });
 
     await refresh();
+    // Resolve only once the admin dismisses the modal. The toolbar handler
+    // holds its action lock across this await, so a second click reports
+    // "already running" instead of stacking a second modal over the same rows.
+    await closed;
   }
 
   // ── IX-F Member Audit (helpers) ────────────────────────────────────────────
@@ -4708,7 +4738,10 @@
     setIconButtonLabel(recentChangesBtn, "\u23f2", `Recent IP changes (\u2264${RECENT_IP_CHANGES_WINDOW_MIN}m)`);
     recentChangesBtn.addEventListener("click", () => {
       if (!isFeatureEnabled("recentIpChanges")) return;
-      openRecentIpChangesModal(String(ixlanId));
+      // Fire-and-forget, so it carries its own handler (docs/CONVENTIONS.md).
+      openRecentIpChangesModal(String(ixlanId)).catch((error) => {
+        console.error(`[${MODULE_PREFIX}] Recent IP changes modal failed`, error);
+      });
     });
     // Right-aligned fixed-offset strip: buttons stay side-by-side.
     buttons.append(closeBtn, refreshBtn, recentChangesBtn, cancelApplyBtn, applyBtn);
@@ -4716,8 +4749,27 @@
     backdrop.appendChild(modal);
     document.body.appendChild(backdrop);
 
-    /** Removes the modal. */
-    function close() { backdrop.remove(); }
+    // Resolves when the modal is dismissed. The opener awaits this, so the
+    // caller's action lock spans the modal's lifetime rather than only its
+    // first render -- otherwise a second click stacks a second modal, with its
+    // own cancelSignal, over rows the first one is still writing.
+    let resolveClosed;
+    const closed = new Promise((resolve) => { resolveClosed = resolve; });
+
+    /**
+     * Removes the modal and cancels any merge loop in flight.
+     * @ai Preserve the cancelSignal write and the resolveClosed() call.
+     */
+    function close() {
+      // Dismissing the UI must stop the work, not just hide it. This was
+      // `backdrop.remove()` alone, so a backdrop click mid-apply tore down the
+      // progress display while the loop kept issuing PUT/DELETE with no
+      // remaining way to abort. The explicit Cancel button already set this
+      // flag; close() did not.
+      cancelSignal.cancelled = true;
+      backdrop.remove();
+      resolveClosed();
+    }
     closeBtn.addEventListener("click", close);
     backdrop.addEventListener("click", (ev) => { if (ev.target === backdrop) close(); });
 
@@ -4817,6 +4869,10 @@
     });
 
     await refresh();
+    // Resolve only once the admin dismisses the modal. The toolbar handler
+    // holds its action lock across this await, so a second click reports
+    // "already running" instead of stacking a second modal over the same rows.
+    await closed;
   }
 
   // ── IXLAN Conflict Resolver (helpers) ──────────────────────────────────────
@@ -5426,11 +5482,14 @@
     confirmLabel.textContent = `Type ixlan id "${ixlanId}" to enable Apply: `;
     const confirmInput = document.createElement("input");
     confirmInput.type = "text";
-    confirmInput.placeholder = normalizedExpectedIxlanId || ixlanId;
-    // Pre-fill to prevent false lockout where the operator sees "3990"
-    // but Apply remains disabled due placeholder/value confusion.
-    // Final window.confirm remains in place as destructive safeguard.
-    confirmInput.value = normalizedExpectedIxlanId;
+    // Deliberately NOT the expected id: a placeholder showing "3990" made an
+    // empty field look filled, which is the "false lockout" the previous
+    // pre-fill was added to work around. That pre-fill satisfied the gate from
+    // first render, so the banner's "type the ixlan id to enable Apply" was
+    // never actually enforced. Fix the confusing placeholder instead and leave
+    // the field empty, so the admin's keystrokes are what enable Apply.
+    // @ai Do NOT set confirmInput.value here.
+    confirmInput.placeholder = "ixlan id";
     Object.assign(confirmInput.style, { padding: "4px 6px", marginLeft: "6px", width: "100px" });
     confirmLabel.appendChild(confirmInput);
     confirmRow.appendChild(confirmLabel);
@@ -5512,7 +5571,25 @@
     backdrop.appendChild(modal);
     document.body.appendChild(backdrop);
 
-    closeBtn.addEventListener("click", () => backdrop.remove());
+    // See the same pattern in openIxlanRenumberModal: resolves on dismissal so
+    // the enclosing action lock covers the modal's whole lifetime.
+    let resolveClosed;
+    const closed = new Promise((resolve) => { resolveClosed = resolve; });
+
+    /**
+     * Removes the modal and cancels any delete loop in flight.
+     * @ai Preserve the cancelSignal write and the resolveClosed() call.
+     */
+    function close() {
+      // Dismissing the UI must stop the work, not just hide it -- this modal
+      // issues DELETEs, and the teardown used to leave the loop running with
+      // no progress display and no way to abort.
+      cancelSignal.cancelled = true;
+      backdrop.remove();
+      resolveClosed();
+    }
+    closeBtn.addEventListener("click", close);
+    backdrop.addEventListener("click", (ev) => { if (ev.target === backdrop) close(); });
 
     // State.
     let items = initialItems.map((it) => ({
@@ -5741,6 +5818,10 @@
     });
 
     await refresh();
+    // Resolve only once the admin dismisses the modal. The toolbar handler
+    // holds its action lock across this await, so a second click reports
+    // "already running" instead of stacking a second modal over the same rows.
+    await closed;
   }
 
   // ── Recent IP Changes Audit Report (helpers) ───────────────────────────────
@@ -6178,7 +6259,19 @@
     backdrop.appendChild(modal);
     document.body.appendChild(backdrop);
 
-    closeBtn.addEventListener("click", () => backdrop.remove());
+    // Read-only report, so there is no cancelSignal to trip -- but the opener
+    // still awaits dismissal, which is what makes the caller's "report is
+    // already open" lock message true rather than aspirational.
+    let resolveClosed;
+    const closed = new Promise((resolve) => { resolveClosed = resolve; });
+
+    /** Removes the modal. */
+    function close() {
+      backdrop.remove();
+      resolveClosed();
+    }
+    closeBtn.addEventListener("click", close);
+    backdrop.addEventListener("click", (ev) => { if (ev.target === backdrop) close(); });
 
     async function refresh() {
       refreshBtn.disabled = true; copyBtn.disabled = true;
@@ -6206,6 +6299,10 @@
     });
 
     await refresh();
+    // Resolve only once the admin dismisses the modal. The toolbar handler
+    // holds its action lock across this await, so a second click reports
+    // "already running" instead of stacking a second modal over the same rows.
+    await closed;
   }
 
   /**

--- a/user.js/tests/cp-modal-safeguards.test.js
+++ b/user.js/tests/cp-modal-safeguards.test.js
@@ -1,0 +1,103 @@
+'use strict';
+
+// Structural guards on CP's four destructive/report modals.
+//
+// These are deliberately *source* assertions, not behavioral ones. The
+// modals are pure DOM wiring, which this repo does not unit test (see the
+// header of cp-ixf-merge-gates.test.js for the same split), and the test
+// shim's FakeElement has no addEventListener at all, so a modal cannot be
+// constructed -- let alone clicked -- through loadScript today.
+//
+// They exist because all three safeguards below were silently absent in
+// shipped code and nothing failed:
+//
+//   * close() removed the backdrop without setting cancelSignal.cancelled,
+//     so dismissing a modal mid-apply tore down the progress display while
+//     the loop kept issuing PUT/DELETE with no remaining way to abort.
+//   * Each opener resolved at its first render, so the caller's action lock
+//     was released while the modal was still open and a second click could
+//     stack a second modal, with its own cancelSignal, over the same rows.
+//   * The conflict resolver pre-filled its type-to-confirm input from first
+//     render, making the banner's "type the ixlan id to enable Apply"
+//     safeguard inert.
+//
+// A source assertion cannot prove the wiring works -- that is what the
+// manual smoke test in AGENTS.md is for -- but it does prove the safeguard
+// has not been deleted again, which is the failure that actually happened.
+// Assertions run against the generated .user.js, because that is what ships.
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const SOURCE = fs.readFileSync(
+  path.join(__dirname, '..', 'peeringdb-cp-consolidated-tools.user.js'),
+  'utf-8',
+);
+
+const MODAL_OPENERS = [
+  'openIxlanRenumberModal',
+  'openIxfMemberAuditModal',
+  'openConflictResolverModal',
+  'openRecentIpChangesModal',
+];
+
+/**
+ * Slices one modal opener's body out of the script source.
+ * @param {string} name - Opener function name.
+ * @returns {string} Source text from the declaration to its closing brace.
+ */
+function openerBody(name) {
+  const start = SOURCE.indexOf(`async function ${name}(`);
+  assert.notEqual(start, -1, `${name} not found -- was it renamed?`);
+  const end = SOURCE.indexOf('\n    await closed;\n  }\n', start);
+  assert.notEqual(end, -1, `${name} does not end by awaiting its close signal`);
+  return SOURCE.slice(start, end);
+}
+
+test('every modal opener holds until the modal is dismissed', async (t) => {
+  for (const name of MODAL_OPENERS) {
+    await t.test(name, () => {
+      const body = openerBody(name);
+      assert.match(body, /const closed = new Promise\(/, 'declares a close signal');
+      assert.match(body, /resolveClosed\(\);/, 'close() resolves it');
+      // The lock the caller holds is only as good as this await; openerBody()
+      // already fails if the terminating `await closed;` is gone.
+    });
+  }
+});
+
+test('dismissing a modal cancels its in-flight write loop', async (t) => {
+  for (const name of MODAL_OPENERS) {
+    await t.test(name, () => {
+      const body = openerBody(name);
+      // Keyed off the declaration, not a bare mention -- prose in a comment
+      // must not make a modal look like it has a cancel signal.
+      if (!/let cancelSignal = \{ cancelled: false \};/.test(body)) {
+        // Read-only report modal -- nothing to cancel. Assert that, rather
+        // than skipping, so adding writes to it fails this test.
+        assert.equal(name, 'openRecentIpChangesModal');
+        return;
+      }
+      const close = body.match(/function close\(\) \{([\s\S]*?)\n {4}\}/);
+      assert.ok(close, `${name} has no close() to inspect`);
+      assert.match(
+        close[1],
+        /cancelSignal\.cancelled = true;/,
+        `${name}'s close() must cancel, not just hide`,
+      );
+    });
+  }
+});
+
+test('the conflict resolver never pre-fills its type-to-confirm input', () => {
+  // The gate is "the admin typed the ixlan id". Any assignment to
+  // confirmInput.value satisfies it without the admin doing anything.
+  assert.doesNotMatch(SOURCE, /confirmInput\.value\s*=/);
+  // ...and the placeholder must not show the expected id either, since that
+  // is what made an empty field look filled and prompted the pre-fill.
+  assert.doesNotMatch(SOURCE, /confirmInput\.placeholder = normalizedExpectedIxlanId/);
+  // The gate itself must still be wired up.
+  assert.match(SOURCE, /confirmInput\.addEventListener\("input", recomputeApplyEnabled\)/);
+});


### PR DESCRIPTION
Dismissing a CP modal hid the work without stopping it. close() was
literally backdrop.remove(), so a backdrop click or Close during an apply
tore down the progress display while the loop kept issuing PUT and DELETE
against live rows -- with no progress shown and no remaining way to
abort, since the Cancel button that sets cancelSignal.cancelled went away
with the modal. The explicit Cancel path had always been correct; close()
simply did not use it.

Two related safeguards were inert for the same reason -- present in the
UI, absent in effect. Each opener resolved at its first render, so the
toolbar handler's action lock was released while the modal was still
open and a second click stacked a second modal, with its own
cancelSignal, over the same rows. And the conflict resolver pre-filled
its type-to-confirm input from first render, so the banner's "type the
ixlan id to enable Apply" gate was satisfied before the admin touched
anything.

Changes:
- close() now sets cancelSignal.cancelled = true before removing the
  backdrop, in the IXLAN renumber, IX-F member audit and conflict
  resolver modals.
- The conflict resolver and recent-IP-changes modals gain a real close()
  and a backdrop-click path; both previously had only an inline
  () => backdrop.remove() on the Close button.
- Each of the four openers now resolves on dismissal rather than on first
  render, so the caller's action lock spans the modal's lifetime. For the
  read-only recent-changes report this is what makes its existing
  "report is already open" message true.
- Drop the conflict resolver's confirmInput.value pre-fill and stop
  showing the expected id as the placeholder -- the placeholder is what
  made an empty field look filled, which is the "false lockout" the
  pre-fill was originally added to work around. The input listeners that
  enable Apply were already wired, so the gate now works as the banner
  describes.
- Give the two fire-and-forget modal launches their own .catch(), per the
  convention added in the pdbFetch commit.

Security:
- Removes a path where an admin who dismissed a modal mid-apply believed
  they had stopped a bulk renumber or merge while PUT/DELETE continued
  against production rows.
- Restores the type-to-confirm gate on the destructive conflict resolver,
  and prevents two concurrent modals from writing to the same ixlan.

Testing:
- node --test: 518 tests, 517 pass, 1 skipped (live tests are opt-in).
- New tests/cp-modal-safeguards.test.js pins all three safeguards. These
  are source assertions, not behavioral ones, and the file says so at
  length: the modals are DOM wiring this repo does not unit test, and the
  shim's FakeElement has no addEventListener, so a modal cannot be
  constructed or clicked through loadScript. They cannot prove the wiring
  works -- the AGENTS.md smoke test covers that -- but they do catch the
  failure that actually happened, which was a safeguard going missing
  with nothing red.
- Each safeguard reverted individually and confirmed red: 4, 10 and 1
  failures respectively.

Backwards Compatibility:
- The four modal openers now settle on dismissal instead of first render.
  All seven call sites are updated here; three already awaited them
  inside the action lock, which is the behavior being corrected.
- No storage, API or audit-log format changes.

Assisted-by: Claude:claude-opus-5

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>