### PR TITLE
fix(cp): plan, re-read and verify before an IX-F merge deletes a row

### DIFF
--- a/user.js/peeringdb-cp-consolidated-tools.src.js
+++ b/user.js/peeringdb-cp-consolidated-tools.src.js
@@ -3141,16 +3141,26 @@
 
   /**
    * Applies a list of merge candidates sequentially.
-    * Purpose: For each candidate, pre-clear the sibling row's transfer IP
-    * (so unique-ip validation does not block keeper PUT), then PUT the
-    * keeper with both ipv4 + ipv6, then DELETE the sibling.
+   * Purpose: For each candidate, re-read both rows live and re-confirm the
+   * pair still merges, pre-clear the sibling row's transfer IP (so unique-ip
+   * validation does not block keeper PUT), PUT the keeper with both IPs plus
+   * anything the doomed row carries that the keeper lacks, verify that landed,
+   * then DELETE the sibling.
+   * Necessity: this loop used to write from the refresh()-time snapshot and
+   * PUT only ipaddr4/ipaddr6, so (a) rows edited between render and Apply were
+   * merged on stale premises, and (b) speed/is_rs_peer/bfd_support/operational
+   * /notes carried solely by the doomed row were destroyed by the DELETE. The
+   * conflict resolver already did all of this correctly; this ports its
+   * discipline rather than introducing a second mechanism.
    * @ai Preserve request retries/timeouts/error classification and payload assumptions.
+   * @ai Do NOT DELETE before the keeper read-back confirms every absorbed field.
    * @param {object[]} candidates - Selected merge candidates.
+   * @param {Map|null} ixfMap - IX-F ASN->pairs map used to re-confirm the pair.
    * @param {{ cancelled: boolean }} signal - External cancel flag.
    * @param {Function} onProgress - Per-row callback.
    * @returns {Promise<object[]>} Outcomes for the audit log.
    */
-  async function applyIxfMerges(candidates, signal, onProgress) {
+  async function applyIxfMerges(candidates, ixfMap, signal, onProgress) {
     const outcomes = [];
     for (const candidate of candidates) {
       const base = {
@@ -3160,6 +3170,8 @@
         ipv4: candidate.ipv4,
         ipv6: candidate.ipv6,
         shape: candidate.shape || "split",
+        absorbed: {},
+        acknowledgedMismatches: [],
       };
       if (signal?.cancelled) {
         outcomes.push({ ...base, status: "cancelled" });
@@ -3168,7 +3180,58 @@
 
       onProgress?.(candidate, { status: "in-flight" });
 
-      const otherOriginal = buildNetixlanPutPayload(candidate.otherRow);
+      const abort = async (status, error, extra = {}) => {
+        const outcome = { ...base, ...extra, status, error };
+        outcomes.push(outcome);
+        onProgress?.(candidate, outcome);
+        if (IXF_MEMBER_APPLY_DELAY_MS > 0) await new Promise((r) => setTimeout(r, IXF_MEMBER_APPLY_DELAY_MS));
+      };
+
+      // Live re-read. Everything below is decided from these rows, never from
+      // the refresh()-time snapshot the table was rendered from.
+      const [freshKeeperRes, freshOtherRes] = await Promise.all([
+        fetchNetixlanRowById(candidate.keeperRow.id),
+        fetchNetixlanRowById(candidate.otherRow.id),
+      ]);
+      if (freshKeeperRes.error || freshOtherRes.error || !freshKeeperRes.row || !freshOtherRes.row) {
+        await abort("aborted", freshKeeperRes.error || freshOtherRes.error || "no-row", { gateFailed: "fresh-reread" });
+        continue;
+      }
+
+      // Re-run the same predicate that produced this candidate, against the
+      // live rows. If the pair no longer merges -- an IP moved, a row was
+      // edited, IX-F no longer confirms it -- this one is out.
+      const liveCandidates = ixfMap
+        ? findIxfMergeCandidates([freshKeeperRes.row, freshOtherRes.row], ixfMap)
+        : [];
+      const liveCandidate = liveCandidates.find((c) =>
+        String(c.keeperRow.id) === String(candidate.keeperRow.id) &&
+        String(c.otherRow.id) === String(candidate.otherRow.id) &&
+        c.ipv4 === candidate.ipv4 &&
+        normalizeIpv6ForCompare(c.ipv6) === normalizeIpv6ForCompare(candidate.ipv6) &&
+        (c.shape || "split") === (candidate.shape || "split"),
+      );
+      if (!liveCandidate) {
+        await abort("aborted", ixfMap ? "live-recheck-failed" : "ixf-map-unavailable", { gateFailed: "live-recheck" });
+        continue;
+      }
+
+      // What this DELETE would absorb, and what it would discard. The
+      // acknowledgement is bound to the exact disagreement set the admin saw;
+      // a set that changed under us is a new decision, not an approved one.
+      const effects = summarizeIxfMergeEffects(liveCandidate);
+      base.absorbed = { ...effects.merge };
+      base.acknowledgedMismatches = effects.mismatches.map((m) => m.field);
+      if (effects.mismatches.length > 0 && candidate.acknowledgedMismatchKey !== effects.mismatchKey) {
+        await abort(
+          "aborted",
+          `unacknowledged-mismatch:${effects.mismatches.map((m) => m.field).join(",")}`,
+          { gateFailed: "mismatch-ack" },
+        );
+        continue;
+      }
+
+      const otherOriginal = buildNetixlanPutPayload(freshOtherRes.row);
       const otherNeutralized = { ...otherOriginal };
       const candidateV4 = String(candidate.ipv4 || "").trim();
       const candidateV6Norm = normalizeIpv6ForCompare(candidate.ipv6 || "");
@@ -3188,7 +3251,7 @@
       }
 
       if (neutralizeChanged) {
-        const otherUrl = `${PEERINGDB_API_BASE_URL}/netixlan/${candidate.otherRow.id}`;
+        const otherUrl = `${PEERINGDB_API_BASE_URL}/netixlan/${freshOtherRes.row.id}`;
         const neutralizeRes = await pdbPost(otherUrl, "PUT", otherNeutralized, { contentType: "application/json", retries: 1 });
         const neutralizeOk = Number(neutralizeRes?.status || 0) >= 200 && Number(neutralizeRes?.status || 0) < 300;
         if (!neutralizeOk) {
@@ -3205,17 +3268,23 @@
         }
       }
 
-      const putBody = buildNetixlanPutPayload(candidate.keeperRow);
+      // Absorb before the DELETE: any preserved field the doomed row carries
+      // and the keeper lacks is copied over, because the DELETE is about to
+      // destroy its only carrier. IPs are set explicitly from the IX-F-
+      // confirmed pair, which is why summarizeIxfMergeEffects skips both
+      // families. Disagreements are not absorbed -- the keeper's value stands,
+      // and the admin has already acknowledged the loss above.
+      const putBody = { ...buildNetixlanPutPayload(freshKeeperRes.row), ...effects.merge };
       putBody.ipaddr4 = candidate.ipv4;
       putBody.ipaddr6 = candidate.ipv6;
-      const putUrl = `${PEERINGDB_API_BASE_URL}/netixlan/${candidate.keeperRow.id}`;
+      const putUrl = `${PEERINGDB_API_BASE_URL}/netixlan/${freshKeeperRes.row.id}`;
       const putResult = await pdbPost(putUrl, "PUT", putBody, { contentType: "application/json", retries: 1 });
       const putOk = Number(putResult?.status || 0) >= 200 && Number(putResult?.status || 0) < 300;
       if (!putOk) {
         let rollbackStatus = 0;
         let rollbackError = "";
         if (neutralizeChanged) {
-          const otherUrl = `${PEERINGDB_API_BASE_URL}/netixlan/${candidate.otherRow.id}`;
+          const otherUrl = `${PEERINGDB_API_BASE_URL}/netixlan/${freshOtherRes.row.id}`;
           const rollbackRes = await pdbPost(otherUrl, "PUT", otherOriginal, { contentType: "application/json", retries: 1 });
           rollbackStatus = Number(rollbackRes?.status || 0);
           const rollbackOk = rollbackStatus >= 200 && rollbackStatus < 300;
@@ -3234,7 +3303,29 @@
         if (IXF_MEMBER_APPLY_DELAY_MS > 0) await new Promise((r) => setTimeout(r, IXF_MEMBER_APPLY_DELAY_MS));
         continue;
       }
-      const delUrl = `${PEERINGDB_API_BASE_URL}/netixlan/${candidate.otherRow.id}`;
+      // Verify the keeper actually holds everything before destroying the only
+      // other copy. Same discipline as applyConflictDeletes: a PUT that
+      // returned 2xx but did not persist a field must not be followed by a
+      // DELETE, because the doomed row is the last carrier.
+      const verifyRes = await fetchNetixlanRowById(freshKeeperRes.row.id);
+      if (verifyRes.error || !verifyRes.row) {
+        await abort("keeper-verify-failed", verifyRes.error || "no-row");
+        continue;
+      }
+      const wanted = { ...effects.merge, ipaddr4: candidate.ipv4, ipaddr6: candidate.ipv6 };
+      const mismatched = [];
+      for (const [field, want] of Object.entries(wanted)) {
+        const got = verifyRes.row[field];
+        if (normalizeNetixlanFieldForCompare(field, want) !== normalizeNetixlanFieldForCompare(field, got)) {
+          mismatched.push(field);
+        }
+      }
+      if (mismatched.length > 0) {
+        await abort("keeper-verify-failed", `mismatch:${mismatched.join(",")}`);
+        continue;
+      }
+
+      const delUrl = `${PEERINGDB_API_BASE_URL}/netixlan/${freshOtherRes.row.id}`;
       const delResult = await pdbPost(delUrl, "DELETE", "", { contentType: "application/json", retries: 1 });
       const delOk = Number(delResult?.status || 0) >= 200 && Number(delResult?.status || 0) < 300;
       const outcome = {
@@ -3388,14 +3479,75 @@
 
     let candidates = [];
     let ixfUrlInUse = "";
+    // Kept at modal scope so applyIxfMerges can re-confirm each pair against
+    // the same IX-F data at write time, not just at render time.
+    let ixfMap = null;
     let cancelSignal = { cancelled: false };
+
+    /**
+     * Builds the "Merge effect" cell: what the keeper absorbs, and any field
+     * both rows disagree on, with the acknowledgement the admin must tick.
+     * Purpose: Put the consequence of the DELETE in front of the admin before
+     * Apply, instead of leaving it to the changelog afterwards.
+     * Necessity: v4-only and v6-only rows are created independently and
+     * commonly disagree on speed or is_rs_peer. Hard-failing every such pair
+     * would block most real merges; merging silently would discard the doomed
+     * row's value with no record. Neither is the admin's call to skip.
+     * @ai Preserve the acknowledgement gate -- applyIxfMerges aborts any
+     *   candidate whose acknowledgedMismatchKey does not match what it re-reads.
+     * @param {object} candidate - Annotated merge candidate.
+     * @returns {HTMLElement} Table cell.
+     */
+    function buildMergeEffectCell(candidate) {
+      const cell = document.createElement("td");
+      Object.assign(cell.style, { padding: "5px 8px", borderBottom: "1px solid #eee", verticalAlign: "top" });
+      const effects = candidate.effects || { merge: {}, mismatches: [], mismatchKey: "" };
+
+      const absorbedFields = Object.keys(effects.merge);
+      if (absorbedFields.length > 0) {
+        const line = document.createElement("div");
+        line.textContent = `absorbs ${absorbedFields.join(", ")}`;
+        Object.assign(line.style, { color: "#15803d" });
+        cell.appendChild(line);
+      }
+
+      if (effects.mismatches.length === 0) {
+        if (absorbedFields.length === 0) {
+          const line = document.createElement("div");
+          line.textContent = "no data loss";
+          Object.assign(line.style, { color: "#666" });
+          cell.appendChild(line);
+        }
+        return cell;
+      }
+
+      for (const mismatch of effects.mismatches) {
+        const line = document.createElement("div");
+        line.textContent = `${mismatch.field}: keeper=${String(mismatch.keeper)} doomed=${String(mismatch.doomed)} (doomed value is discarded)`;
+        Object.assign(line.style, { color: "#b91c1c" });
+        cell.appendChild(line);
+      }
+
+      const ackLabel = document.createElement("label");
+      Object.assign(ackLabel.style, { display: "block", marginTop: "3px", color: "#b91c1c", cursor: "pointer" });
+      const ack = document.createElement("input");
+      ack.type = "checkbox";
+      ack.checked = candidate.acknowledgedMismatchKey === effects.mismatchKey;
+      ack.addEventListener("change", () => {
+        candidate.acknowledgedMismatchKey = ack.checked ? effects.mismatchKey : "";
+      });
+      ackLabel.appendChild(ack);
+      ackLabel.appendChild(document.createTextNode(" I reviewed this mismatch"));
+      cell.appendChild(ackLabel);
+      return cell;
+    }
 
     /** Re-renders the candidate table. */
     function render() {
       table.textContent = "";
       const thead = document.createElement("thead");
       const trh = document.createElement("tr");
-      for (const label of ["✓", "ASN", "Shape", "Keeper id", "Other id", "IPv4", "IPv6", "Status"]) {
+      for (const label of ["✓", "ASN", "Shape", "Keeper id", "Other id", "IPv4", "IPv6", "Merge effect", "Status"]) {
         const th = document.createElement("th");
         th.textContent = label;
         Object.assign(th.style, { textAlign: "left", padding: "6px 8px", borderBottom: "1px solid #ccc", background: "#fafafa", position: "sticky", top: "0" });
@@ -3418,7 +3570,7 @@
           shapeCell.title = "v4-only keeper + dual stale row: absorb v6, DELETE the stale row whose v4 disagrees with IX-F.";
           Object.assign(shapeCell.style, { color: "#b45309", fontWeight: "600" });
         }
-        tr.append(cbCell, td(candidate.asn), shapeCell, td(candidate.keeperRow.id), td(candidate.otherRow.id), td(candidate.ipv4 || ""), td(candidate.ipv6 || ""), td(candidate.applyStatus || "ready"));
+        tr.append(cbCell, td(candidate.asn), shapeCell, td(candidate.keeperRow.id), td(candidate.otherRow.id), td(candidate.ipv4 || ""), td(candidate.ipv6 || ""), buildMergeEffectCell(candidate), td(candidate.applyStatus || "ready"));
         tbody.appendChild(tr);
       }
       table.appendChild(tbody);
@@ -3448,9 +3600,23 @@
         status.textContent = "PDB netixlan fetch failed.";
         candidates = []; render(); return;
       }
-      const ixfMap = extractIxfAsnIpPairs(ixfResult.data);
-      candidates = findIxfMergeCandidates(rows, ixfMap).map((c) => ({ ...c, selected: true, applyStatus: "" }));
-      status.textContent = `ixlan #${ixlanId} — ${rows.length} PDB rows • ${ixfMap.size} IX-F ASNs • ${candidates.length} mergeable split pair(s)`;
+      ixfMap = extractIxfAsnIpPairs(ixfResult.data);
+      candidates = findIxfMergeCandidates(rows, ixfMap).map((c) => {
+        const effects = summarizeIxfMergeEffects(c);
+        return {
+          ...c,
+          selected: true,
+          applyStatus: "",
+          effects,
+          // Set only when the admin ticks the row's acknowledgement box, and
+          // compared by value at apply time so a disagreement that changed in
+          // between re-prompts instead of riding on the old tick.
+          acknowledgedMismatchKey: "",
+        };
+      });
+      const reviewCount = candidates.filter((c) => c.effects.mismatches.length > 0).length;
+      status.textContent = `ixlan #${ixlanId} — ${rows.length} PDB rows • ${ixfMap.size} IX-F ASNs • ${candidates.length} mergeable split pair(s)`
+        + (reviewCount ? ` • ${reviewCount} need mismatch review` : "");
       render();
     }
 
@@ -3458,9 +3624,25 @@
     applyBtn.addEventListener("click", async () => {
       const selected = candidates.filter((c) => c.selected);
       if (selected.length === 0) { status.textContent = "Nothing selected to apply."; return; }
+      // Refuse the whole batch rather than silently skipping rows: a partial
+      // apply that quietly dropped the rows needing review would read as
+      // success. applyIxfMerges re-checks this against live data anyway; this
+      // is the early, legible failure.
+      const unreviewed = selected.filter(
+        (c) => c.effects.mismatches.length > 0 && c.acknowledgedMismatchKey !== c.effects.mismatchKey,
+      );
+      if (unreviewed.length > 0) {
+        status.textContent = `Review the mismatch on ${unreviewed.length} selected row(s) first `
+          + `(AS${unreviewed.map((c) => c.asn).join(", AS")}), or unselect them.`;
+        return;
+      }
+      const absorbing = selected.filter((c) => Object.keys(c.effects.merge).length > 0).length;
+      const discarding = selected.filter((c) => c.effects.mismatches.length > 0).length;
       const confirmed = window.confirm(
         `Merge ${selected.length} split netixlan pair(s)?\n` +
-        `Each merge will pre-clear the sibling transfer IP if needed, PUT both IPs onto the older (lower-id) row, then DELETE the sibling.\n` +
+        `Each merge re-reads both rows, pre-clears the sibling transfer IP if needed, PUTs both IPs onto the older (lower-id) row, verifies it, then DELETEs the sibling.\n` +
+        `Absorbing fields from the deleted row: ${absorbing}\n` +
+        `Discarding a disagreeing value you acknowledged: ${discarding}\n` +
         `ixlan: #${ixlanId}\n` +
         `IX-F source: ${ixfUrlInUse}`,
       );
@@ -3468,17 +3650,20 @@
       applyBtn.disabled = true; refreshBtn.disabled = true;
       cancelApplyBtn.style.display = ""; cancelSignal = { cancelled: false };
       cancelApplyBtn.onclick = () => { cancelSignal.cancelled = true; };
-      const outcomes = await applyIxfMerges(selected, cancelSignal, (candidate, update) => {
+      const outcomes = await applyIxfMerges(selected, ixfMap, cancelSignal, (candidate, update) => {
         candidate.applyStatus = update.status === "in-flight" ? "applying…" : `${update.status}${update.httpStatus ? ` (${update.httpStatus})` : ""}${update.error ? ` — ${update.error}` : ""}`;
         render();
       });
       recordIxfMergeAuditEntry({ ixlanId, ixfUrl: ixfUrlInUse, outcomes });
       applyBtn.disabled = false; refreshBtn.disabled = false; cancelApplyBtn.style.display = "none";
-      const ok = outcomes.filter((o) => o.status === "done").length;
-      const preclearErr = outcomes.filter((o) => o.status === "preclear-failed").length;
-      const putErr = outcomes.filter((o) => o.status === "put-failed").length;
-      const delErr = outcomes.filter((o) => o.status === "delete-failed").length;
-      status.textContent = `Apply complete — ok:${ok} preclear-failed:${preclearErr} put-failed:${putErr} delete-failed:${delErr} cancelled:${outcomes.filter((o) => o.status === "cancelled").length}`;
+      const count = (s) => outcomes.filter((o) => o.status === s).length;
+      status.textContent = `Apply complete — ok:${count("done")} aborted:${count("aborted")} `
+        + `preclear-failed:${count("preclear-failed")} put-failed:${count("put-failed")} `
+        + `keeper-verify-failed:${count("keeper-verify-failed")} delete-failed:${count("delete-failed")} `
+        + `cancelled:${count("cancelled")}`;
+      // Aborted rows are the ones a live re-read disqualified; refresh so the
+      // table reflects why rather than leaving a stale "ready".
+      if (count("aborted") > 0) await refresh();
     });
 
     await refresh();
@@ -3601,13 +3786,15 @@
    *
    * Skips the conflicting family entirely — the renumber flow already
    * gives the keeper its post-renumber IP on that family (gates 3 & 4
-   * verify this).
+   * verify this). `family: "both"` skips ipaddr4 and ipaddr6 together, for
+   * the IX-F merge path, which writes both addresses onto the keeper from
+   * the IX-F-confirmed pair and so owns neither field's merge decision.
    *
    * Purpose: Prevent IP-family / attribute data loss when a DELETE would
    * otherwise destroy the only carrier of a value (operator-discovered
    * bug: ixlan #3990, doomed #93168 IPv6 would have been lost).
    * @ai Preserve normalization/parsing rules and backward-compatible output formats.
-   * @param {{ doomedRow: object, keeperRow: object, family: 4|6 }} args
+   * @param {{ doomedRow: object, keeperRow: object, family: 4|6|"both" }} args
    * @returns {{ merge: object, blockers: Array<{ field: string, kind: string, doomed: *, keeper: * }> }}
    */
   function buildMergePlan(args) {
@@ -3615,9 +3802,11 @@
     const merge = {};
     const blockers = [];
     if (!doomedRow || !keeperRow) return { merge, blockers };
-    const conflictingFamilyField = family === 4 ? "ipaddr4" : "ipaddr6";
+    const skippedFamilyFields = family === "both"
+      ? ["ipaddr4", "ipaddr6"]
+      : [family === 4 ? "ipaddr4" : "ipaddr6"];
     for (const field of PRESERVED_NETIXLAN_FIELDS) {
-      if (field === conflictingFamilyField) continue;
+      if (skippedFamilyFields.includes(field)) continue;
       const d = doomedRow[field];
       const k = keeperRow[field];
       const dHas = isMergeableValue(d);
@@ -3639,6 +3828,42 @@
       }
     }
     return { merge, blockers };
+  }
+
+  /**
+   * Summarizes what an IX-F merge would absorb from the doomed row and what
+   * it would discard.
+   * Purpose: Give the audit modal a per-candidate answer to "does this DELETE
+   * destroy anything?" so mismatches can be shown before Apply rather than
+   * discovered in the changelog afterwards.
+   * Necessity: applyIxfMerges used to PUT only ipaddr4/ipaddr6 onto the
+   * keeper, so speed/is_rs_peer/bfd_support/operational/notes carried solely
+   * by the doomed row were destroyed by the DELETE with nothing recorded.
+   * Split v4-only/v6-only rows are created independently and disagree often,
+   * so a mismatch is a normal finding to review, not an error.
+   * @ai Preserve normalization/parsing rules and backward-compatible output formats.
+   * @param {{ keeperRow: object, otherRow: object }} candidate - Merge candidate.
+   * @returns {{ merge: object, mismatches: Array<{ field: string, keeper: *, doomed: * }>,
+   *             mismatchKey: string }} Fields to absorb, disagreements to review,
+   *   and a stable key identifying the disagreement set.
+   */
+  function summarizeIxfMergeEffects(candidate) {
+    const plan = buildMergePlan({
+      doomedRow: candidate?.otherRow,
+      keeperRow: candidate?.keeperRow,
+      family: "both",
+    });
+    const mismatches = plan.blockers
+      .filter((b) => b.kind === "field-mismatch")
+      .map((b) => ({ field: b.field, keeper: b.keeper, doomed: b.doomed }));
+    // Stable identity for the disagreement set, so an acknowledgement made
+    // against what the admin saw cannot silently carry over to a different
+    // set discovered during the live re-read at apply time.
+    const mismatchKey = mismatches
+      .map((m) => `${m.field}=${String(m.keeper)}|${String(m.doomed)}`)
+      .sort()
+      .join(";");
+    return { merge: plan.merge, mismatches, mismatchKey };
   }
 
   /**
@@ -11310,6 +11535,8 @@
       extractIxfAsnIpPairs,
       findIxfMergeCandidates,
       buildMergePlan,
+      summarizeIxfMergeEffects,
+      applyIxfMerges,
       verifyConflictGates,
       classifyNetworkNamePattern,
       buildNetworkNamePatternSummary,

--- a/user.js/peeringdb-cp-consolidated-tools.user.js
+++ b/user.js/peeringdb-cp-consolidated-tools.user.js
@@ -4528,16 +4528,26 @@
 
   /**
    * Applies a list of merge candidates sequentially.
-    * Purpose: For each candidate, pre-clear the sibling row's transfer IP
-    * (so unique-ip validation does not block keeper PUT), then PUT the
-    * keeper with both ipv4 + ipv6, then DELETE the sibling.
+   * Purpose: For each candidate, re-read both rows live and re-confirm the
+   * pair still merges, pre-clear the sibling row's transfer IP (so unique-ip
+   * validation does not block keeper PUT), PUT the keeper with both IPs plus
+   * anything the doomed row carries that the keeper lacks, verify that landed,
+   * then DELETE the sibling.
+   * Necessity: this loop used to write from the refresh()-time snapshot and
+   * PUT only ipaddr4/ipaddr6, so (a) rows edited between render and Apply were
+   * merged on stale premises, and (b) speed/is_rs_peer/bfd_support/operational
+   * /notes carried solely by the doomed row were destroyed by the DELETE. The
+   * conflict resolver already did all of this correctly; this ports its
+   * discipline rather than introducing a second mechanism.
    * @ai Preserve request retries/timeouts/error classification and payload assumptions.
+   * @ai Do NOT DELETE before the keeper read-back confirms every absorbed field.
    * @param {object[]} candidates - Selected merge candidates.
+   * @param {Map|null} ixfMap - IX-F ASN->pairs map used to re-confirm the pair.
    * @param {{ cancelled: boolean }} signal - External cancel flag.
    * @param {Function} onProgress - Per-row callback.
    * @returns {Promise<object[]>} Outcomes for the audit log.
    */
-  async function applyIxfMerges(candidates, signal, onProgress) {
+  async function applyIxfMerges(candidates, ixfMap, signal, onProgress) {
     const outcomes = [];
     for (const candidate of candidates) {
       const base = {
@@ -4547,6 +4557,8 @@
         ipv4: candidate.ipv4,
         ipv6: candidate.ipv6,
         shape: candidate.shape || "split",
+        absorbed: {},
+        acknowledgedMismatches: [],
       };
       if (signal?.cancelled) {
         outcomes.push({ ...base, status: "cancelled" });
@@ -4555,7 +4567,58 @@
 
       onProgress?.(candidate, { status: "in-flight" });
 
-      const otherOriginal = buildNetixlanPutPayload(candidate.otherRow);
+      const abort = async (status, error, extra = {}) => {
+        const outcome = { ...base, ...extra, status, error };
+        outcomes.push(outcome);
+        onProgress?.(candidate, outcome);
+        if (IXF_MEMBER_APPLY_DELAY_MS > 0) await new Promise((r) => setTimeout(r, IXF_MEMBER_APPLY_DELAY_MS));
+      };
+
+      // Live re-read. Everything below is decided from these rows, never from
+      // the refresh()-time snapshot the table was rendered from.
+      const [freshKeeperRes, freshOtherRes] = await Promise.all([
+        fetchNetixlanRowById(candidate.keeperRow.id),
+        fetchNetixlanRowById(candidate.otherRow.id),
+      ]);
+      if (freshKeeperRes.error || freshOtherRes.error || !freshKeeperRes.row || !freshOtherRes.row) {
+        await abort("aborted", freshKeeperRes.error || freshOtherRes.error || "no-row", { gateFailed: "fresh-reread" });
+        continue;
+      }
+
+      // Re-run the same predicate that produced this candidate, against the
+      // live rows. If the pair no longer merges -- an IP moved, a row was
+      // edited, IX-F no longer confirms it -- this one is out.
+      const liveCandidates = ixfMap
+        ? findIxfMergeCandidates([freshKeeperRes.row, freshOtherRes.row], ixfMap)
+        : [];
+      const liveCandidate = liveCandidates.find((c) =>
+        String(c.keeperRow.id) === String(candidate.keeperRow.id) &&
+        String(c.otherRow.id) === String(candidate.otherRow.id) &&
+        c.ipv4 === candidate.ipv4 &&
+        normalizeIpv6ForCompare(c.ipv6) === normalizeIpv6ForCompare(candidate.ipv6) &&
+        (c.shape || "split") === (candidate.shape || "split"),
+      );
+      if (!liveCandidate) {
+        await abort("aborted", ixfMap ? "live-recheck-failed" : "ixf-map-unavailable", { gateFailed: "live-recheck" });
+        continue;
+      }
+
+      // What this DELETE would absorb, and what it would discard. The
+      // acknowledgement is bound to the exact disagreement set the admin saw;
+      // a set that changed under us is a new decision, not an approved one.
+      const effects = summarizeIxfMergeEffects(liveCandidate);
+      base.absorbed = { ...effects.merge };
+      base.acknowledgedMismatches = effects.mismatches.map((m) => m.field);
+      if (effects.mismatches.length > 0 && candidate.acknowledgedMismatchKey !== effects.mismatchKey) {
+        await abort(
+          "aborted",
+          `unacknowledged-mismatch:${effects.mismatches.map((m) => m.field).join(",")}`,
+          { gateFailed: "mismatch-ack" },
+        );
+        continue;
+      }
+
+      const otherOriginal = buildNetixlanPutPayload(freshOtherRes.row);
       const otherNeutralized = { ...otherOriginal };
       const candidateV4 = String(candidate.ipv4 || "").trim();
       const candidateV6Norm = normalizeIpv6ForCompare(candidate.ipv6 || "");
@@ -4575,7 +4638,7 @@
       }
 
       if (neutralizeChanged) {
-        const otherUrl = `${PEERINGDB_API_BASE_URL}/netixlan/${candidate.otherRow.id}`;
+        const otherUrl = `${PEERINGDB_API_BASE_URL}/netixlan/${freshOtherRes.row.id}`;
         const neutralizeRes = await pdbPost(otherUrl, "PUT", otherNeutralized, { contentType: "application/json", retries: 1 });
         const neutralizeOk = Number(neutralizeRes?.status || 0) >= 200 && Number(neutralizeRes?.status || 0) < 300;
         if (!neutralizeOk) {
@@ -4592,17 +4655,23 @@
         }
       }
 
-      const putBody = buildNetixlanPutPayload(candidate.keeperRow);
+      // Absorb before the DELETE: any preserved field the doomed row carries
+      // and the keeper lacks is copied over, because the DELETE is about to
+      // destroy its only carrier. IPs are set explicitly from the IX-F-
+      // confirmed pair, which is why summarizeIxfMergeEffects skips both
+      // families. Disagreements are not absorbed -- the keeper's value stands,
+      // and the admin has already acknowledged the loss above.
+      const putBody = { ...buildNetixlanPutPayload(freshKeeperRes.row), ...effects.merge };
       putBody.ipaddr4 = candidate.ipv4;
       putBody.ipaddr6 = candidate.ipv6;
-      const putUrl = `${PEERINGDB_API_BASE_URL}/netixlan/${candidate.keeperRow.id}`;
+      const putUrl = `${PEERINGDB_API_BASE_URL}/netixlan/${freshKeeperRes.row.id}`;
       const putResult = await pdbPost(putUrl, "PUT", putBody, { contentType: "application/json", retries: 1 });
       const putOk = Number(putResult?.status || 0) >= 200 && Number(putResult?.status || 0) < 300;
       if (!putOk) {
         let rollbackStatus = 0;
         let rollbackError = "";
         if (neutralizeChanged) {
-          const otherUrl = `${PEERINGDB_API_BASE_URL}/netixlan/${candidate.otherRow.id}`;
+          const otherUrl = `${PEERINGDB_API_BASE_URL}/netixlan/${freshOtherRes.row.id}`;
           const rollbackRes = await pdbPost(otherUrl, "PUT", otherOriginal, { contentType: "application/json", retries: 1 });
           rollbackStatus = Number(rollbackRes?.status || 0);
           const rollbackOk = rollbackStatus >= 200 && rollbackStatus < 300;
@@ -4621,7 +4690,29 @@
         if (IXF_MEMBER_APPLY_DELAY_MS > 0) await new Promise((r) => setTimeout(r, IXF_MEMBER_APPLY_DELAY_MS));
         continue;
       }
-      const delUrl = `${PEERINGDB_API_BASE_URL}/netixlan/${candidate.otherRow.id}`;
+      // Verify the keeper actually holds everything before destroying the only
+      // other copy. Same discipline as applyConflictDeletes: a PUT that
+      // returned 2xx but did not persist a field must not be followed by a
+      // DELETE, because the doomed row is the last carrier.
+      const verifyRes = await fetchNetixlanRowById(freshKeeperRes.row.id);
+      if (verifyRes.error || !verifyRes.row) {
+        await abort("keeper-verify-failed", verifyRes.error || "no-row");
+        continue;
+      }
+      const wanted = { ...effects.merge, ipaddr4: candidate.ipv4, ipaddr6: candidate.ipv6 };
+      const mismatched = [];
+      for (const [field, want] of Object.entries(wanted)) {
+        const got = verifyRes.row[field];
+        if (normalizeNetixlanFieldForCompare(field, want) !== normalizeNetixlanFieldForCompare(field, got)) {
+          mismatched.push(field);
+        }
+      }
+      if (mismatched.length > 0) {
+        await abort("keeper-verify-failed", `mismatch:${mismatched.join(",")}`);
+        continue;
+      }
+
+      const delUrl = `${PEERINGDB_API_BASE_URL}/netixlan/${freshOtherRes.row.id}`;
       const delResult = await pdbPost(delUrl, "DELETE", "", { contentType: "application/json", retries: 1 });
       const delOk = Number(delResult?.status || 0) >= 200 && Number(delResult?.status || 0) < 300;
       const outcome = {
@@ -4775,14 +4866,75 @@
 
     let candidates = [];
     let ixfUrlInUse = "";
+    // Kept at modal scope so applyIxfMerges can re-confirm each pair against
+    // the same IX-F data at write time, not just at render time.
+    let ixfMap = null;
     let cancelSignal = { cancelled: false };
+
+    /**
+     * Builds the "Merge effect" cell: what the keeper absorbs, and any field
+     * both rows disagree on, with the acknowledgement the admin must tick.
+     * Purpose: Put the consequence of the DELETE in front of the admin before
+     * Apply, instead of leaving it to the changelog afterwards.
+     * Necessity: v4-only and v6-only rows are created independently and
+     * commonly disagree on speed or is_rs_peer. Hard-failing every such pair
+     * would block most real merges; merging silently would discard the doomed
+     * row's value with no record. Neither is the admin's call to skip.
+     * @ai Preserve the acknowledgement gate -- applyIxfMerges aborts any
+     *   candidate whose acknowledgedMismatchKey does not match what it re-reads.
+     * @param {object} candidate - Annotated merge candidate.
+     * @returns {HTMLElement} Table cell.
+     */
+    function buildMergeEffectCell(candidate) {
+      const cell = document.createElement("td");
+      Object.assign(cell.style, { padding: "5px 8px", borderBottom: "1px solid #eee", verticalAlign: "top" });
+      const effects = candidate.effects || { merge: {}, mismatches: [], mismatchKey: "" };
+
+      const absorbedFields = Object.keys(effects.merge);
+      if (absorbedFields.length > 0) {
+        const line = document.createElement("div");
+        line.textContent = `absorbs ${absorbedFields.join(", ")}`;
+        Object.assign(line.style, { color: "#15803d" });
+        cell.appendChild(line);
+      }
+
+      if (effects.mismatches.length === 0) {
+        if (absorbedFields.length === 0) {
+          const line = document.createElement("div");
+          line.textContent = "no data loss";
+          Object.assign(line.style, { color: "#666" });
+          cell.appendChild(line);
+        }
+        return cell;
+      }
+
+      for (const mismatch of effects.mismatches) {
+        const line = document.createElement("div");
+        line.textContent = `${mismatch.field}: keeper=${String(mismatch.keeper)} doomed=${String(mismatch.doomed)} (doomed value is discarded)`;
+        Object.assign(line.style, { color: "#b91c1c" });
+        cell.appendChild(line);
+      }
+
+      const ackLabel = document.createElement("label");
+      Object.assign(ackLabel.style, { display: "block", marginTop: "3px", color: "#b91c1c", cursor: "pointer" });
+      const ack = document.createElement("input");
+      ack.type = "checkbox";
+      ack.checked = candidate.acknowledgedMismatchKey === effects.mismatchKey;
+      ack.addEventListener("change", () => {
+        candidate.acknowledgedMismatchKey = ack.checked ? effects.mismatchKey : "";
+      });
+      ackLabel.appendChild(ack);
+      ackLabel.appendChild(document.createTextNode(" I reviewed this mismatch"));
+      cell.appendChild(ackLabel);
+      return cell;
+    }
 
     /** Re-renders the candidate table. */
     function render() {
       table.textContent = "";
       const thead = document.createElement("thead");
       const trh = document.createElement("tr");
-      for (const label of ["✓", "ASN", "Shape", "Keeper id", "Other id", "IPv4", "IPv6", "Status"]) {
+      for (const label of ["✓", "ASN", "Shape", "Keeper id", "Other id", "IPv4", "IPv6", "Merge effect", "Status"]) {
         const th = document.createElement("th");
         th.textContent = label;
         Object.assign(th.style, { textAlign: "left", padding: "6px 8px", borderBottom: "1px solid #ccc", background: "#fafafa", position: "sticky", top: "0" });
@@ -4805,7 +4957,7 @@
           shapeCell.title = "v4-only keeper + dual stale row: absorb v6, DELETE the stale row whose v4 disagrees with IX-F.";
           Object.assign(shapeCell.style, { color: "#b45309", fontWeight: "600" });
         }
-        tr.append(cbCell, td(candidate.asn), shapeCell, td(candidate.keeperRow.id), td(candidate.otherRow.id), td(candidate.ipv4 || ""), td(candidate.ipv6 || ""), td(candidate.applyStatus || "ready"));
+        tr.append(cbCell, td(candidate.asn), shapeCell, td(candidate.keeperRow.id), td(candidate.otherRow.id), td(candidate.ipv4 || ""), td(candidate.ipv6 || ""), buildMergeEffectCell(candidate), td(candidate.applyStatus || "ready"));
         tbody.appendChild(tr);
       }
       table.appendChild(tbody);
@@ -4835,9 +4987,23 @@
         status.textContent = "PDB netixlan fetch failed.";
         candidates = []; render(); return;
       }
-      const ixfMap = extractIxfAsnIpPairs(ixfResult.data);
-      candidates = findIxfMergeCandidates(rows, ixfMap).map((c) => ({ ...c, selected: true, applyStatus: "" }));
-      status.textContent = `ixlan #${ixlanId} — ${rows.length} PDB rows • ${ixfMap.size} IX-F ASNs • ${candidates.length} mergeable split pair(s)`;
+      ixfMap = extractIxfAsnIpPairs(ixfResult.data);
+      candidates = findIxfMergeCandidates(rows, ixfMap).map((c) => {
+        const effects = summarizeIxfMergeEffects(c);
+        return {
+          ...c,
+          selected: true,
+          applyStatus: "",
+          effects,
+          // Set only when the admin ticks the row's acknowledgement box, and
+          // compared by value at apply time so a disagreement that changed in
+          // between re-prompts instead of riding on the old tick.
+          acknowledgedMismatchKey: "",
+        };
+      });
+      const reviewCount = candidates.filter((c) => c.effects.mismatches.length > 0).length;
+      status.textContent = `ixlan #${ixlanId} — ${rows.length} PDB rows • ${ixfMap.size} IX-F ASNs • ${candidates.length} mergeable split pair(s)`
+        + (reviewCount ? ` • ${reviewCount} need mismatch review` : "");
       render();
     }
 
@@ -4845,9 +5011,25 @@
     applyBtn.addEventListener("click", async () => {
       const selected = candidates.filter((c) => c.selected);
       if (selected.length === 0) { status.textContent = "Nothing selected to apply."; return; }
+      // Refuse the whole batch rather than silently skipping rows: a partial
+      // apply that quietly dropped the rows needing review would read as
+      // success. applyIxfMerges re-checks this against live data anyway; this
+      // is the early, legible failure.
+      const unreviewed = selected.filter(
+        (c) => c.effects.mismatches.length > 0 && c.acknowledgedMismatchKey !== c.effects.mismatchKey,
+      );
+      if (unreviewed.length > 0) {
+        status.textContent = `Review the mismatch on ${unreviewed.length} selected row(s) first `
+          + `(AS${unreviewed.map((c) => c.asn).join(", AS")}), or unselect them.`;
+        return;
+      }
+      const absorbing = selected.filter((c) => Object.keys(c.effects.merge).length > 0).length;
+      const discarding = selected.filter((c) => c.effects.mismatches.length > 0).length;
       const confirmed = window.confirm(
         `Merge ${selected.length} split netixlan pair(s)?\n` +
-        `Each merge will pre-clear the sibling transfer IP if needed, PUT both IPs onto the older (lower-id) row, then DELETE the sibling.\n` +
+        `Each merge re-reads both rows, pre-clears the sibling transfer IP if needed, PUTs both IPs onto the older (lower-id) row, verifies it, then DELETEs the sibling.\n` +
+        `Absorbing fields from the deleted row: ${absorbing}\n` +
+        `Discarding a disagreeing value you acknowledged: ${discarding}\n` +
         `ixlan: #${ixlanId}\n` +
         `IX-F source: ${ixfUrlInUse}`,
       );
@@ -4855,17 +5037,20 @@
       applyBtn.disabled = true; refreshBtn.disabled = true;
       cancelApplyBtn.style.display = ""; cancelSignal = { cancelled: false };
       cancelApplyBtn.onclick = () => { cancelSignal.cancelled = true; };
-      const outcomes = await applyIxfMerges(selected, cancelSignal, (candidate, update) => {
+      const outcomes = await applyIxfMerges(selected, ixfMap, cancelSignal, (candidate, update) => {
         candidate.applyStatus = update.status === "in-flight" ? "applying…" : `${update.status}${update.httpStatus ? ` (${update.httpStatus})` : ""}${update.error ? ` — ${update.error}` : ""}`;
         render();
       });
       recordIxfMergeAuditEntry({ ixlanId, ixfUrl: ixfUrlInUse, outcomes });
       applyBtn.disabled = false; refreshBtn.disabled = false; cancelApplyBtn.style.display = "none";
-      const ok = outcomes.filter((o) => o.status === "done").length;
-      const preclearErr = outcomes.filter((o) => o.status === "preclear-failed").length;
-      const putErr = outcomes.filter((o) => o.status === "put-failed").length;
-      const delErr = outcomes.filter((o) => o.status === "delete-failed").length;
-      status.textContent = `Apply complete — ok:${ok} preclear-failed:${preclearErr} put-failed:${putErr} delete-failed:${delErr} cancelled:${outcomes.filter((o) => o.status === "cancelled").length}`;
+      const count = (s) => outcomes.filter((o) => o.status === s).length;
+      status.textContent = `Apply complete — ok:${count("done")} aborted:${count("aborted")} `
+        + `preclear-failed:${count("preclear-failed")} put-failed:${count("put-failed")} `
+        + `keeper-verify-failed:${count("keeper-verify-failed")} delete-failed:${count("delete-failed")} `
+        + `cancelled:${count("cancelled")}`;
+      // Aborted rows are the ones a live re-read disqualified; refresh so the
+      // table reflects why rather than leaving a stale "ready".
+      if (count("aborted") > 0) await refresh();
     });
 
     await refresh();
@@ -4988,13 +5173,15 @@
    *
    * Skips the conflicting family entirely — the renumber flow already
    * gives the keeper its post-renumber IP on that family (gates 3 & 4
-   * verify this).
+   * verify this). `family: "both"` skips ipaddr4 and ipaddr6 together, for
+   * the IX-F merge path, which writes both addresses onto the keeper from
+   * the IX-F-confirmed pair and so owns neither field's merge decision.
    *
    * Purpose: Prevent IP-family / attribute data loss when a DELETE would
    * otherwise destroy the only carrier of a value (operator-discovered
    * bug: ixlan #3990, doomed #93168 IPv6 would have been lost).
    * @ai Preserve normalization/parsing rules and backward-compatible output formats.
-   * @param {{ doomedRow: object, keeperRow: object, family: 4|6 }} args
+   * @param {{ doomedRow: object, keeperRow: object, family: 4|6|"both" }} args
    * @returns {{ merge: object, blockers: Array<{ field: string, kind: string, doomed: *, keeper: * }> }}
    */
   function buildMergePlan(args) {
@@ -5002,9 +5189,11 @@
     const merge = {};
     const blockers = [];
     if (!doomedRow || !keeperRow) return { merge, blockers };
-    const conflictingFamilyField = family === 4 ? "ipaddr4" : "ipaddr6";
+    const skippedFamilyFields = family === "both"
+      ? ["ipaddr4", "ipaddr6"]
+      : [family === 4 ? "ipaddr4" : "ipaddr6"];
     for (const field of PRESERVED_NETIXLAN_FIELDS) {
-      if (field === conflictingFamilyField) continue;
+      if (skippedFamilyFields.includes(field)) continue;
       const d = doomedRow[field];
       const k = keeperRow[field];
       const dHas = isMergeableValue(d);
@@ -5026,6 +5215,42 @@
       }
     }
     return { merge, blockers };
+  }
+
+  /**
+   * Summarizes what an IX-F merge would absorb from the doomed row and what
+   * it would discard.
+   * Purpose: Give the audit modal a per-candidate answer to "does this DELETE
+   * destroy anything?" so mismatches can be shown before Apply rather than
+   * discovered in the changelog afterwards.
+   * Necessity: applyIxfMerges used to PUT only ipaddr4/ipaddr6 onto the
+   * keeper, so speed/is_rs_peer/bfd_support/operational/notes carried solely
+   * by the doomed row were destroyed by the DELETE with nothing recorded.
+   * Split v4-only/v6-only rows are created independently and disagree often,
+   * so a mismatch is a normal finding to review, not an error.
+   * @ai Preserve normalization/parsing rules and backward-compatible output formats.
+   * @param {{ keeperRow: object, otherRow: object }} candidate - Merge candidate.
+   * @returns {{ merge: object, mismatches: Array<{ field: string, keeper: *, doomed: * }>,
+   *             mismatchKey: string }} Fields to absorb, disagreements to review,
+   *   and a stable key identifying the disagreement set.
+   */
+  function summarizeIxfMergeEffects(candidate) {
+    const plan = buildMergePlan({
+      doomedRow: candidate?.otherRow,
+      keeperRow: candidate?.keeperRow,
+      family: "both",
+    });
+    const mismatches = plan.blockers
+      .filter((b) => b.kind === "field-mismatch")
+      .map((b) => ({ field: b.field, keeper: b.keeper, doomed: b.doomed }));
+    // Stable identity for the disagreement set, so an acknowledgement made
+    // against what the admin saw cannot silently carry over to a different
+    // set discovered during the live re-read at apply time.
+    const mismatchKey = mismatches
+      .map((m) => `${m.field}=${String(m.keeper)}|${String(m.doomed)}`)
+      .sort()
+      .join(";");
+    return { merge: plan.merge, mismatches, mismatchKey };
   }
 
   /**
@@ -12697,6 +12922,8 @@
       extractIxfAsnIpPairs,
       findIxfMergeCandidates,
       buildMergePlan,
+      summarizeIxfMergeEffects,
+      applyIxfMerges,
       verifyConflictGates,
       classifyNetworkNamePattern,
       buildNetworkNamePatternSummary,

--- a/user.js/tests/browser-shim.test.js
+++ b/user.js/tests/browser-shim.test.js
@@ -82,3 +82,50 @@ test('every request is recorded with its method, so retries are observable', asy
   assert.equal(fetchCalls[0].url, url);
   assert.equal(fetchCalls[2].body, '{"speed":1000}');
 });
+
+test('a __sequence entry serves its responses in order, then repeats the last', async () => {
+  // Read-modify-verify flows need a URL to answer differently before and
+  // after a write; CP's IX-F merge re-reads the keeper to confirm a PUT
+  // landed before deleting the only other copy.
+  const url = 'https://www.peeringdb.com/api/net/9';
+  const { window } = loadScript(SCRIPT_PATH, {
+    hooksKey: '__pdbDpTestHooks__',
+    pathname: '/app/ticket',
+    fetchMap: {
+      [url]: {
+        __sequence: [
+          { data: [{ id: 9, name: 'before' }] },
+          { data: [{ id: 9, name: 'after' }] },
+        ],
+      },
+    },
+  });
+
+  assert.equal((await (await window.fetch(url)).json()).data[0].name, 'before');
+  assert.equal((await (await window.fetch(url)).json()).data[0].name, 'after');
+  // Exhausted: the last element repeats rather than 404ing, so a flow that
+  // re-reads more than the fixture anticipated does not fail confusingly.
+  assert.equal((await (await window.fetch(url)).json()).data[0].name, 'after');
+});
+
+test('a __sequence element may itself be a response descriptor', async () => {
+  const url = 'https://www.peeringdb.com/api/net/10';
+  const { window } = loadScript(SCRIPT_PATH, {
+    hooksKey: '__pdbDpTestHooks__',
+    pathname: '/app/ticket',
+    fetchMap: {
+      [url]: {
+        __sequence: [
+          { __response: true, status: 503, body: {}, headers: { 'Retry-After': '0' } },
+          { data: [{ id: 10 }] },
+        ],
+      },
+    },
+  });
+
+  const first = await window.fetch(url);
+  assert.equal(first.status, 503);
+  assert.equal(first.headers.get('retry-after'), '0');
+  const second = await window.fetch(url);
+  assert.equal(second.status, 200);
+});

--- a/user.js/tests/cp-ixf-merge-apply.test.js
+++ b/user.js/tests/cp-ixf-merge-apply.test.js
@@ -1,0 +1,296 @@
+'use strict';
+
+// Integration tests for CP's IX-F merge apply loop (applyIxfMerges).
+//
+// Unlike cp-ixf-merge-gates.test.js, which unit tests the pure candidate and
+// gate helpers, these drive the real write path end to end through the shim:
+// pdbPost and fetchNetixlanRowById both go through window.fetch for
+// same-origin requests, and the shim's fake fetch records every call's method
+// and body. That recording is what makes the ordering assertions below
+// possible -- notably "no DELETE was issued", which is the entire point of
+// the read-back verification.
+//
+// The loop previously wrote from the refresh()-time snapshot and PUT only
+// ipaddr4/ipaddr6, so a DELETE destroyed any speed/is_rs_peer/bfd_support/
+// operational/notes value carried solely by the doomed row, and a row edited
+// between render and Apply was merged on stale premises. It also never
+// re-read the keeper before deleting the only other copy.
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const { loadScript } = require('./helpers/browser-shim');
+
+const SCRIPT_PATH = path.join(__dirname, '..', 'peeringdb-cp-consolidated-tools.user.js');
+const ORIGIN = 'https://www.peeringdb.com';
+const rowUrl = (id) => `${ORIGIN}/api/netixlan/${id}?depth=0`;
+const writeUrl = (id) => `${ORIGIN}/api/netixlan/${id}`;
+
+const KEEPER_ID = 100; // lower id -> keeper
+const OTHER_ID = 200;
+const V4 = '80.81.194.210';
+const V6 = '2001:7f8:1::a500:64500:1';
+
+/**
+ * Builds a netixlan row with the fields the merge path cares about.
+ * @param {number} id - Row id.
+ * @param {object} overrides - Field overrides.
+ * @returns {object} Netixlan row.
+ */
+function row(id, overrides = {}) {
+  return {
+    id,
+    asn: 64500,
+    ixlan_id: 42,
+    ipaddr4: '',
+    ipaddr6: '',
+    speed: 10000,
+    operational: true,
+    is_rs_peer: false,
+    bfd_support: false,
+    notes: '',
+    status: 'ok',
+    net_id: 7,
+    ...overrides,
+  };
+}
+
+const v4Only = () => row(KEEPER_ID, { ipaddr4: V4 });
+const v6Only = () => row(OTHER_ID, { ipaddr6: V6 });
+
+/**
+ * Loads CP against a fake API where each netixlan id resolves to a given row.
+ * @param {object} opts - Rows to serve and optional per-id write responses.
+ * @returns {object} Test hooks, recorded fetch calls, and an IX-F map.
+ */
+function loadMergeScenario({ keeper, other, keeperReadback }) {
+  const fetchMap = {
+    // The keeper is read twice: once to decide the merge, once after the PUT
+    // to confirm it landed. Without keeperReadback the second read returns the
+    // unchanged row, which is exactly the "PUT said 2xx but did not persist"
+    // case the DELETE must refuse to follow.
+    [rowUrl(KEEPER_ID)]: { __sequence: [{ data: [keeper] }, { data: [keeperReadback || keeper] }] },
+    [rowUrl(OTHER_ID)]: { data: [other] },
+    [writeUrl(KEEPER_ID)]: { data: [keeperReadback || keeper] },
+    [writeUrl(OTHER_ID)]: { data: [other] },
+  };
+  const { hooks, fetchCalls } = loadScript(SCRIPT_PATH, {
+    hooksKey: '__pdbCpTestHooks__',
+    pathname: '/cp/peeringdb_server/networkixlan/',
+    fetchMap,
+  });
+  const ixfMap = new Map([['64500', [{ v4: V4, v6: V6, v6Norm: V6.toLowerCase() }]]]);
+  return { hooks, fetchCalls, ixfMap };
+}
+
+/**
+ * Returns the single candidate findIxfMergeCandidates produces for a pair.
+ * Built by the real finder rather than hand-rolled, so a fixture that stops
+ * being a valid merge candidate fails loudly here instead of silently
+ * exercising a shape the tool would never produce.
+ * @param {object} hooks - Script test hooks.
+ * @param {object} keeper - Keeper row.
+ * @param {object} other - Doomed row.
+ * @param {Map} ixfMap - IX-F pairs by ASN.
+ * @returns {object} Merge candidate.
+ */
+function candidateFor(hooks, keeper, other, ixfMap) {
+  const found = hooks.findIxfMergeCandidates([keeper, other], ixfMap);
+  assert.equal(found.length, 1, 'fixture must produce exactly one merge candidate');
+  return found[0];
+}
+
+test('summarizeIxfMergeEffects reports what the DELETE would destroy', async (t) => {
+  const { hooks, ixfMap } = loadMergeScenario({ keeper: v4Only(), other: v6Only() });
+
+  await t.test('a field only the doomed row carries is absorbed', () => {
+    const keeper = v4Only();
+    const other = row(OTHER_ID, { ipaddr6: V6, notes: 'LAG member' });
+    const effects = hooks.summarizeIxfMergeEffects(candidateFor(hooks, keeper, other, ixfMap));
+    assert.equal(effects.merge.notes, 'LAG member');
+    // Length, not deepEqual: arrays crossing the vm realm boundary fail
+    // deepStrictEqual on prototype identity.
+    assert.equal(effects.mismatches.length, 0);
+  });
+
+  await t.test('a field both rows carry differently is a mismatch, not a merge', () => {
+    const keeper = row(KEEPER_ID, { ipaddr4: V4, speed: 10000 });
+    const other = row(OTHER_ID, { ipaddr6: V6, speed: 1000 });
+    const effects = hooks.summarizeIxfMergeEffects(candidateFor(hooks, keeper, other, ixfMap));
+    assert.equal('speed' in effects.merge, false, 'a disagreement must not be auto-absorbed');
+    assert.equal(effects.mismatches.length, 1);
+    assert.equal(effects.mismatches[0].field, 'speed');
+    assert.equal(effects.mismatches[0].keeper, 10000);
+    assert.equal(effects.mismatches[0].doomed, 1000);
+  });
+
+  await t.test('neither IP family is ever part of the plan', () => {
+    // applyIxfMerges writes both addresses explicitly from the IX-F pair, so
+    // a plan that also carried them could fight that explicit assignment.
+    const effects = hooks.summarizeIxfMergeEffects(candidateFor(hooks, v4Only(), v6Only(), ixfMap));
+    assert.equal('ipaddr4' in effects.merge, false);
+    assert.equal('ipaddr6' in effects.merge, false);
+  });
+
+  await t.test('the mismatch key changes when the disagreement changes', () => {
+    const a = hooks.summarizeIxfMergeEffects(candidateFor(
+      hooks, row(KEEPER_ID, { ipaddr4: V4, speed: 10000 }), row(OTHER_ID, { ipaddr6: V6, speed: 1000 }), ixfMap,
+    ));
+    const b = hooks.summarizeIxfMergeEffects(candidateFor(
+      hooks, row(KEEPER_ID, { ipaddr4: V4, speed: 10000 }), row(OTHER_ID, { ipaddr6: V6, speed: 2000 }), ixfMap,
+    ));
+    assert.notEqual(a.mismatchKey, b.mismatchKey, 'an acknowledgement must not carry across a changed value');
+  });
+});
+
+test('applyIxfMerges absorbs fields the DELETE would otherwise destroy', async () => {
+  const keeper = v4Only();
+  const other = row(OTHER_ID, { ipaddr6: V6, notes: 'LAG member', is_rs_peer: true });
+  // The keeper reads back with everything applied, so verification passes and
+  // the loop is allowed to reach its DELETE.
+  const keeperReadback = row(KEEPER_ID, {
+    ipaddr4: V4, ipaddr6: V6, notes: 'LAG member', is_rs_peer: true,
+  });
+  const { hooks, fetchCalls, ixfMap } = loadMergeScenario({ keeper, other, keeperReadback });
+
+  const outcomes = await hooks.applyIxfMerges(
+    [{ ...candidateFor(hooks, keeper, other, ixfMap), acknowledgedMismatchKey: '' }],
+    ixfMap,
+    { cancelled: false },
+    () => {},
+  );
+
+  assert.equal(outcomes.length, 1);
+  const put = fetchCalls.find((c) => c.method === 'PUT' && c.url === writeUrl(KEEPER_ID));
+  assert.ok(put, 'the keeper must be PUT');
+  const body = JSON.parse(put.body);
+  assert.equal(body.ipaddr4, V4);
+  assert.equal(body.ipaddr6, V6);
+  assert.equal(body.notes, 'LAG member', 'notes carried only by the doomed row must be absorbed');
+  assert.equal(body.is_rs_peer, true, 'is_rs_peer carried only by the doomed row must be absorbed');
+  assert.equal(outcomes[0].absorbed.notes, 'LAG member', 'the audit log must record what was absorbed');
+});
+
+test('applyIxfMerges refuses a candidate whose mismatch was never acknowledged', async () => {
+  const keeper = row(KEEPER_ID, { ipaddr4: V4, speed: 10000 });
+  const other = row(OTHER_ID, { ipaddr6: V6, speed: 1000 });
+  const { hooks, fetchCalls, ixfMap } = loadMergeScenario({ keeper, other });
+
+  const outcomes = await hooks.applyIxfMerges(
+    [{ ...candidateFor(hooks, keeper, other, ixfMap), acknowledgedMismatchKey: '' }],
+    ixfMap,
+    { cancelled: false },
+    () => {},
+  );
+
+  assert.equal(outcomes[0].status, 'aborted');
+  assert.equal(outcomes[0].gateFailed, 'mismatch-ack');
+  assert.match(outcomes[0].error, /unacknowledged-mismatch:speed/);
+  assert.equal(fetchCalls.some((c) => c.method === 'DELETE'), false, 'nothing may be deleted');
+  assert.equal(fetchCalls.some((c) => c.method === 'PUT'), false, 'nothing may be written');
+});
+
+test('an acknowledgement for a different disagreement does not carry over', async () => {
+  const keeper = row(KEEPER_ID, { ipaddr4: V4, speed: 10000 });
+  const other = row(OTHER_ID, { ipaddr6: V6, speed: 1000 });
+  const { hooks, fetchCalls, ixfMap } = loadMergeScenario({ keeper, other });
+
+  const outcomes = await hooks.applyIxfMerges(
+    // Correctly shaped, but for a doomed value the live rows no longer carry.
+    [{ ...candidateFor(hooks, keeper, other, ixfMap), acknowledgedMismatchKey: 'speed=10000|2000' }],
+    ixfMap,
+    { cancelled: false },
+    () => {},
+  );
+
+  assert.equal(outcomes[0].status, 'aborted');
+  assert.equal(outcomes[0].gateFailed, 'mismatch-ack');
+  assert.equal(fetchCalls.some((c) => c.method === 'DELETE'), false);
+});
+
+test('an acknowledgement matching the live disagreement lets the merge run', async () => {
+  // The other half of the gate: it must not be unconditionally closed, or the
+  // three assertions above would pass against a tool that never merges.
+  const keeper = row(KEEPER_ID, { ipaddr4: V4, speed: 10000 });
+  const other = row(OTHER_ID, { ipaddr6: V6, speed: 1000 });
+  const keeperReadback = row(KEEPER_ID, { ipaddr4: V4, ipaddr6: V6, speed: 10000 });
+  const { hooks, fetchCalls, ixfMap } = loadMergeScenario({ keeper, other, keeperReadback });
+
+  const candidate = candidateFor(hooks, keeper, other, ixfMap);
+  const { mismatchKey } = hooks.summarizeIxfMergeEffects(candidate);
+  const outcomes = await hooks.applyIxfMerges(
+    [{ ...candidate, acknowledgedMismatchKey: mismatchKey }],
+    ixfMap,
+    { cancelled: false },
+    () => {},
+  );
+
+  assert.equal(outcomes[0].status, 'done');
+  assert.equal(outcomes[0].acknowledgedMismatches.length, 1);
+  assert.equal(outcomes[0].acknowledgedMismatches[0], 'speed');
+  assert.ok(
+    fetchCalls.some((c) => c.method === 'DELETE' && c.url === writeUrl(OTHER_ID)),
+    'an acknowledged merge must still complete',
+  );
+  const put = fetchCalls.find((c) => c.method === 'PUT' && c.url === writeUrl(KEEPER_ID));
+  assert.equal(JSON.parse(put.body).speed, 10000, 'the keeper value stands on a disagreement');
+});
+
+test('applyIxfMerges aborts when the live rows no longer merge', async () => {
+  // The table was rendered from a clean v4-only/v6-only split, but by apply
+  // time the sibling has grown a v4 and the pair is no longer that shape.
+  const rendered = loadMergeScenario({ keeper: v4Only(), other: v6Only() });
+  const candidate = candidateFor(rendered.hooks, v4Only(), v6Only(), rendered.ixfMap);
+
+  const live = loadMergeScenario({
+    keeper: v4Only(),
+    other: row(OTHER_ID, { ipaddr4: '80.81.194.211', ipaddr6: V6 }),
+  });
+  const outcomes = await live.hooks.applyIxfMerges(
+    [{ ...candidate, acknowledgedMismatchKey: '' }],
+    live.ixfMap,
+    { cancelled: false },
+    () => {},
+  );
+
+  assert.equal(outcomes[0].status, 'aborted');
+  assert.equal(outcomes[0].gateFailed, 'live-recheck');
+  assert.equal(live.fetchCalls.some((c) => c.method === 'DELETE'), false, 'a stale premise must not delete');
+});
+
+test('applyIxfMerges never DELETEs when the keeper read-back disagrees', async () => {
+  const keeper = v4Only();
+  const other = row(OTHER_ID, { ipaddr6: V6, notes: 'LAG member' });
+  // No keeperReadback override: the keeper still reads back v4-only, i.e. the
+  // PUT reported success but did not persist. The doomed row is therefore
+  // still the only carrier of ipaddr6 and notes.
+  const { hooks, fetchCalls, ixfMap } = loadMergeScenario({ keeper, other });
+
+  const outcomes = await hooks.applyIxfMerges(
+    [{ ...candidateFor(hooks, keeper, other, ixfMap), acknowledgedMismatchKey: '' }],
+    ixfMap,
+    { cancelled: false },
+    () => {},
+  );
+
+  assert.equal(outcomes[0].status, 'keeper-verify-failed');
+  assert.match(outcomes[0].error, /^mismatch:/);
+  assert.equal(fetchCalls.some((c) => c.method === 'DELETE'), false, 'the last carrier must survive');
+});
+
+test('applyIxfMerges aborts rather than guessing when the IX-F map is unavailable', async () => {
+  const keeper = v4Only();
+  const other = v6Only();
+  const { hooks, fetchCalls, ixfMap } = loadMergeScenario({ keeper, other });
+
+  const outcomes = await hooks.applyIxfMerges(
+    [{ ...candidateFor(hooks, keeper, other, ixfMap), acknowledgedMismatchKey: '' }],
+    null,
+    { cancelled: false },
+    () => {},
+  );
+
+  assert.equal(outcomes[0].status, 'aborted');
+  assert.equal(outcomes[0].error, 'ixf-map-unavailable');
+  assert.equal(fetchCalls.some((c) => c.method === 'DELETE'), false);
+});

--- a/user.js/tests/helpers/browser-shim.js
+++ b/user.js/tests/helpers/browser-shim.js
@@ -296,7 +296,22 @@ function makeFakeFetch(fetchMap, calls) {
       return makeFakeResponse(404, {});
     }
 
-    const entry = fetchMap[key];
+    let entry = fetchMap[key];
+
+    // A { __sequence: [...] } entry serves its elements in order, repeating
+    // the last one once exhausted. Read-modify-verify flows need this: CP's
+    // IX-F merge GETs the keeper, PUTs it, then GETs it again to confirm the
+    // write landed before deleting the only other copy -- and a single static
+    // response per URL cannot express "different after the write". Each
+    // element is itself a bare body or a __response descriptor.
+    if (entry && typeof entry === 'object' && Array.isArray(entry.__sequence)) {
+      const seq = entry.__sequence;
+      if (seq.length === 0) return makeFakeResponse(404, {});
+      const index = Math.min(entry.__served || 0, seq.length - 1);
+      entry.__served = (entry.__served || 0) + 1;
+      entry = seq[index];
+    }
+
     if (entry && typeof entry === 'object' && entry.__response === true) {
       return makeFakeResponse(
         typeof entry.status === 'number' ? entry.status : 200,


### PR DESCRIPTION
applyIxfMerges wrote from the snapshot the table was rendered from and
PUT only ipaddr4/ipaddr6 onto the keeper, then DELETEd the sibling. Two
consequences, both silent. Any preserved field carried solely by the
doomed row -- speed, is_rs_peer, bfd_support, operational, notes -- was
destroyed by that DELETE with nothing recorded, the exact data-loss class
buildMergePlan was written for and which applyIxfMerges never called. And
because nothing was re-read, a row edited between render and Apply was
merged on premises that no longer held.

The conflict resolver already did all of this correctly. This ports its
discipline -- live re-read, re-run the same predicate on the live rows,
absorb before destroying, verify the write landed before deleting the
only other copy -- rather than introducing a second mechanism.

Split v4-only and v6-only rows are created independently and commonly
disagree on speed or is_rs_peer, so hard-failing every disagreement the
way the conflict resolver's gate 8 does would block most real merges.
Instead the audit table now shows, per candidate, what the keeper
absorbs and which value the DELETE discards, and a row with a
disagreement cannot be applied until the admin ticks an acknowledgement
for that specific disagreement.

Changes:
- buildMergePlan accepts family: "both", skipping ipaddr4 and ipaddr6
  together for the IX-F path, which sets both from the IX-F-confirmed
  pair and so owns neither field's merge decision.
- Add summarizeIxfMergeEffects: what a merge absorbs, what it discards,
  and a stable key identifying the disagreement set.
- applyIxfMerges takes ixfMap, re-reads both rows, re-runs
  findIxfMergeCandidates on the live pair and aborts if it no longer
  merges, aborts when the acknowledgement does not match the live
  disagreement set, absorbs the doomed row's gaps into the keeper PUT,
  and re-reads the keeper to confirm every field before the DELETE.
- Audit-log outcomes gain `absorbed` and `acknowledgedMismatches`.
- The audit modal gains a "Merge effect" column with the per-row
  acknowledgement, holds ixfMap at modal scope, blocks Apply on
  unreviewed rows, reports the counts in the confirm dialog, and
  refreshes after any aborted row.
- Test shim: fetchMap entries accept { __sequence: [...] }, serving
  responses in order and repeating the last. A read-modify-verify flow
  cannot be tested without a URL that answers differently after a write.

Security:
- An IX-F merge can no longer delete the last carrier of a value: the
  keeper must be re-read and confirmed to hold it first.
- A merge can no longer proceed on a stale premise; if the live pair
  no longer satisfies findIxfMergeCandidates, the row aborts unwritten.
- With no IX-F map the loop aborts rather than merging unconfirmed, the
  same "200% sure over 90%" stance as conflict-resolver gates 5 and 6.

Testing:
- node --test: 532 tests, 531 pass, 1 skipped (live tests are opt-in).
- New tests/cp-ixf-merge-apply.test.js drives the real write path through
  the shim, asserting on recorded request methods -- including that no
  DELETE is issued when the read-back disagrees, when the live re-check
  fails, when a mismatch is unacknowledged, and when the IX-F map is
  absent. Candidates come from the real findIxfMergeCandidates, so a
  fixture that stops being a valid merge fails loudly.
- A companion case proves an acknowledged mismatch still completes, so
  the gate is not vacuously closed.
- Two self-tests for the new shim capability in browser-shim.test.js.
- Each of the four safeguards reverted individually and confirmed red.
- DOM wiring for the new column is covered by the AGENTS.md smoke test,
  per this repo's testing split.

Backwards Compatibility:
- applyIxfMerges gains an ixfMap parameter in second position; its only
  caller is updated here. It is newly exported on the test hooks.
- buildMergePlan's existing 4 and 6 callers are unaffected.
- Audit-log entries gain fields; readers tolerate unknown keys.

Assisted-by: Claude:claude-opus-5

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>