### PR TITLE
fix(cp): remove the tautological API-coverage self-check

### DIFF
--- a/user.js/peeringdb-cp-consolidated-tools.meta.js
+++ b/user.js/peeringdb-cp-consolidated-tools.meta.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         PeeringDB CP - Consolidated Tools
 // @namespace    https://www.peeringdb.com/cp/
-// @version      2.0.227
+// @version      2.0.228
 // @description  Consolidated CP userscript with strict route-isolated modules for facility/network/user/entity workflows
 // @author       <chriztoffer@peeringdb.com>
 // @match        https://www.peeringdb.com/cp/*

--- a/user.js/peeringdb-cp-consolidated-tools.src.js
+++ b/user.js/peeringdb-cp-consolidated-tools.src.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         PeeringDB CP - Consolidated Tools
 // @namespace    https://www.peeringdb.com/cp/
-// @version      2.0.227
+// @version      2.0.228
 // @description  Consolidated CP userscript with strict route-isolated modules for facility/network/user/entity workflows
 // @author       <chriztoffer@peeringdb.com>
 // @match        https://www.peeringdb.com/cp/*
@@ -258,6 +258,9 @@
   /**
    * API resource mapping by CP entity type.
    * Includes additional CP object types exposed by PeeringDB OpenAPI endpoints.
+   * Note: a real coverage self-check for this map needs an independent source
+   * of truth (e.g. a fetched OpenAPI spec); a check derived from this map
+   * itself is tautological and was removed for that reason.
    */
   const ENTITY_API_RESOURCE_MAP = {
     ...ENTITY_SLUG_MAP,
@@ -269,15 +272,6 @@
     ixlanprefix: "ixpfx",
     carrierfacility: "carrierfac",
   };
-  /**
-   * Derived from ENTITY_API_RESOURCE_MAP (single source of truth for CP
-   * entity -> reftag) rather than hand-duplicated, so a future reftag
-   * addition/typo there can't silently drift out of sync with this set.
-   */
-  const OPENAPI_KNOWN_RESOURCE_SLUGS = new Set([
-    ...Object.values(ENTITY_API_RESOURCE_MAP),
-  ]);
-
   /**
    * Django admin inline-set DOM ID prefixes for network child relations.
    * Used by markDeletedNetworkInlinesForDeletion to iterate all inline sets.
@@ -3988,7 +3982,6 @@
       baseOutcome.mergePlan = { ...liveMerge };
 
       // Phase 1 — Merge into keeper, if there is anything to absorb.
-      let keeperRowForDelete = freshKeeperRes.row;
       if (Object.keys(liveMerge).length > 0) {
         const mergedPayload = { ...buildNetixlanPutPayload(freshKeeperRes.row), ...liveMerge };
         const putUrl = `${PEERINGDB_API_BASE_URL}/netixlan/${item.keeperRow.id}`;
@@ -4043,7 +4036,6 @@
           if (CONFLICT_RESOLVE_APPLY_DELAY_MS > 0) await new Promise((r) => setTimeout(r, CONFLICT_RESOLVE_APPLY_DELAY_MS));
           continue;
         }
-        keeperRowForDelete = verifyRes.row;
         baseOutcome.phase = "merge-then-delete";
       } else {
         baseOutcome.phase = "delete-only";
@@ -5037,30 +5029,6 @@
    */
   function shouldShowApiJsonAction(ctx) {
     return !getApiJsonActionBlockReason(ctx);
-  }
-
-  /**
-   * Debug-only OpenAPI coverage check for mapped CP API resources.
-   * Purpose: Catch accidental resource-slug typos or drift early in diagnostics mode.
-   * Necessity: ENTITY_API_RESOURCE_MAP is a critical integration point for API links/fetches.
-   */
-  function runApiResourceCoverageCheck() {
-    if (!isDebugEnabled()) return;
-
-    const mappedResources = Object.values(ENTITY_API_RESOURCE_MAP)
-      .map((slug) => String(slug || "").trim())
-      .filter(Boolean);
-
-    const unknownResources = mappedResources.filter((slug) => !OPENAPI_KNOWN_RESOURCE_SLUGS.has(slug));
-    if (unknownResources.length > 0) {
-      console.warn(
-        `[${MODULE_PREFIX}] self-check: unmapped OpenAPI resource slug(s) detected`,
-        unknownResources,
-      );
-      return;
-    }
-
-    dbg("self-check", "api resource coverage ok", { count: mappedResources.length });
   }
 
   /**
@@ -11183,8 +11151,6 @@
    * @param {{ entity: string, entityId: string, pathName: string }} ctx - Route context.
    */
   function runSelfCheck(ctx) {
-    runApiResourceCoverageCheck();
-
     const checks = [
       { id: "grp-content",       selector: "#grp-content",             critical: true },
       { id: "grp-content-title", selector: "#grp-content-title",       critical: true },

--- a/user.js/peeringdb-cp-consolidated-tools.user.js
+++ b/user.js/peeringdb-cp-consolidated-tools.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         PeeringDB CP - Consolidated Tools
 // @namespace    https://www.peeringdb.com/cp/
-// @version      2.0.227
+// @version      2.0.228
 // @description  Consolidated CP userscript with strict route-isolated modules for facility/network/user/entity workflows
 // @author       <chriztoffer@peeringdb.com>
 // @match        https://www.peeringdb.com/cp/*
@@ -361,6 +361,9 @@
   /**
    * API resource mapping by CP entity type.
    * Includes additional CP object types exposed by PeeringDB OpenAPI endpoints.
+   * Note: a real coverage self-check for this map needs an independent source
+   * of truth (e.g. a fetched OpenAPI spec); a check derived from this map
+   * itself is tautological and was removed for that reason.
    */
   const ENTITY_API_RESOURCE_MAP = {
     ...ENTITY_SLUG_MAP,
@@ -372,15 +375,6 @@
     ixlanprefix: "ixpfx",
     carrierfacility: "carrierfac",
   };
-  /**
-   * Derived from ENTITY_API_RESOURCE_MAP (single source of truth for CP
-   * entity -> reftag) rather than hand-duplicated, so a future reftag
-   * addition/typo there can't silently drift out of sync with this set.
-   */
-  const OPENAPI_KNOWN_RESOURCE_SLUGS = new Set([
-    ...Object.values(ENTITY_API_RESOURCE_MAP),
-  ]);
-
   /**
    * Django admin inline-set DOM ID prefixes for network child relations.
    * Used by markDeletedNetworkInlinesForDeletion to iterate all inline sets.
@@ -5449,7 +5443,6 @@
       baseOutcome.mergePlan = { ...liveMerge };
 
       // Phase 1 — Merge into keeper, if there is anything to absorb.
-      let keeperRowForDelete = freshKeeperRes.row;
       if (Object.keys(liveMerge).length > 0) {
         const mergedPayload = { ...buildNetixlanPutPayload(freshKeeperRes.row), ...liveMerge };
         const putUrl = `${PEERINGDB_API_BASE_URL}/netixlan/${item.keeperRow.id}`;
@@ -5504,7 +5497,6 @@
           if (CONFLICT_RESOLVE_APPLY_DELAY_MS > 0) await new Promise((r) => setTimeout(r, CONFLICT_RESOLVE_APPLY_DELAY_MS));
           continue;
         }
-        keeperRowForDelete = verifyRes.row;
         baseOutcome.phase = "merge-then-delete";
       } else {
         baseOutcome.phase = "delete-only";
@@ -6498,30 +6490,6 @@
    */
   function shouldShowApiJsonAction(ctx) {
     return !getApiJsonActionBlockReason(ctx);
-  }
-
-  /**
-   * Debug-only OpenAPI coverage check for mapped CP API resources.
-   * Purpose: Catch accidental resource-slug typos or drift early in diagnostics mode.
-   * Necessity: ENTITY_API_RESOURCE_MAP is a critical integration point for API links/fetches.
-   */
-  function runApiResourceCoverageCheck() {
-    if (!isDebugEnabled()) return;
-
-    const mappedResources = Object.values(ENTITY_API_RESOURCE_MAP)
-      .map((slug) => String(slug || "").trim())
-      .filter(Boolean);
-
-    const unknownResources = mappedResources.filter((slug) => !OPENAPI_KNOWN_RESOURCE_SLUGS.has(slug));
-    if (unknownResources.length > 0) {
-      console.warn(
-        `[${MODULE_PREFIX}] self-check: unmapped OpenAPI resource slug(s) detected`,
-        unknownResources,
-      );
-      return;
-    }
-
-    dbg("self-check", "api resource coverage ok", { count: mappedResources.length });
   }
 
   /**
@@ -12644,8 +12612,6 @@
    * @param {{ entity: string, entityId: string, pathName: string }} ctx - Route context.
    */
   function runSelfCheck(ctx) {
-    runApiResourceCoverageCheck();
-
     const checks = [
       { id: "grp-content",       selector: "#grp-content",             critical: true },
       { id: "grp-content-title", selector: "#grp-content-title",       critical: true },


### PR DESCRIPTION
runApiResourceCoverageCheck validated ENTITY_API_RESOURCE_MAP's slugs
against OPENAPI_KNOWN_RESOURCE_SLUGS -- a set built from
ENTITY_API_RESOURCE_MAP itself, so the check could never fire while
reporting green in debug mode. A guard that cannot fire but reports
success is worse than no guard: it manufactures false confidence. A
real coverage check needs an independent source of truth (a fetched
OpenAPI spec); until one exists, no check is honest, and a note on the
map says so. Also removes the dead keeperRowForDelete variable in the
conflict-resolver apply loop, assigned twice and never read.

Changes:
- Delete runApiResourceCoverageCheck, OPENAPI_KNOWN_RESOURCE_SLUGS and
  the runSelfCheck call site.
- Add a note on ENTITY_API_RESOURCE_MAP explaining why there is no
  self-check and what a real one requires.
- Delete the two dead keeperRowForDelete assignments in the IX-F
  conflict-resolver apply loop (the DELETE targets item.doomedRow.id;
  the keeper read-back result was never consumed via this variable).
- Bump CP @version to 2.0.228 (src + meta); regenerate .user.js.

Security:
- N/A (the removed check never guarded anything -- it was structurally
  unable to fail).

Testing:
- Full suite green: 585 pass, 0 fail (includes the IX-F merge-apply
  suite, which pins the conflict-resolver write path this touches).
- build --check and node --check on the regenerated .user.js: clean.
- Verified by grep that zero references remain to the deleted symbols.

Backwards Compatibility:
- Debug mode no longer logs the meaningless "api resource coverage ok"
  self-check line; no other observable change.

Assisted-by: Claude:claude-opus-5

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>


